### PR TITLE
Migrate to win32 5.5.4

### DIFF
--- a/flutter_secure_storage_windows/CHANGELOG.md
+++ b/flutter_secure_storage_windows/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT
+Migrates to `win32` version 5.5.4 to support Dart 3.4 / Flutter 3.22.0.
+
 ## 3.1.2
 Reverts onCupertinoProtectedDataAvailabilityChanged and isCupertinoProtectedDataAvailable.
 

--- a/flutter_secure_storage_windows/example/pubspec.yaml
+++ b/flutter_secure_storage_windows/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the flutter_secure_storage_windows plugin.
 publish_to: 'none'
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=2.0.0"
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: '>=3.22.0'
 
 dependencies:
   flutter:

--- a/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_ffi.dart
+++ b/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_ffi.dart
@@ -246,9 +246,7 @@ class DpapiJsonFileMapStorage extends MapStorage {
 
         if (plainTextBlob.ref.pbData.address == NULL) {
           throw WindowsException(
-            // TODO: New member requires win32 ^5.4.0
-            // ignore: deprecated_member_use
-            ERROR_OUTOFMEMORY,
+            WIN32_ERROR.ERROR_OUTOFMEMORY,
             message: 'Failure on CryptUnprotectData()',
           );
         }
@@ -350,9 +348,7 @@ class DpapiJsonFileMapStorage extends MapStorage {
 
       if (encryptedTextBlob.ref.pbData.address == NULL) {
         throw WindowsException(
-          // TODO: New member requires win32 ^5.4.0
-          // ignore: deprecated_member_use
-          ERROR_OUTOFMEMORY,
+          WIN32_ERROR.ERROR_OUTOFMEMORY,
           message: 'Failure on CryptProtectData()',
         );
       }

--- a/flutter_secure_storage_windows/pubspec.yaml
+++ b/flutter_secure_storage_windows/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_secure_storage_platform_interface: ^1.1.0
   path: ^1.8.0
   path_provider: ^2.0.0
-  win32: ^5.0.0
+  win32: ^5.5.4
 
 dev_dependencies:
   flutter_test:

--- a/flutter_secure_storage_windows/pubspec.yaml
+++ b/flutter_secure_storage_windows/pubspec.yaml
@@ -4,8 +4,8 @@ repository: https://github.com/mogol/flutter_secure_storage
 version: 3.1.2
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
-  flutter: ">=2.0.0"
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: '>=3.22.0'
 
 dependencies:
   ffi: ^2.0.0


### PR DESCRIPTION
This PR migrates `flutter_secure_storage_windows` to support Dart 3.4.0 / Flutter 3.22.0 (and by extension also Dart 3.5.0 / Flutter 3.24.0)

I did not update the version of `flutter_secure_storage_windows`, as changing the supported Flutter version could possibly be seen as a breaking change. That said, if we use the new version constraint for the latest Flutter stable across all of `flutter_secure_storage`, you could also start cleaning up the deprecated usages of `describeEnum()` (which are the only ignores in this plugin's Dart code AFAIK)

Fixes #779 