### PR TITLE
Fix null check error and improve error handling in web implementation

### DIFF
--- a/flutter_secure_storage_web/lib/flutter_secure_storage_web.dart
+++ b/flutter_secure_storage_web/lib/flutter_secure_storage_web.dart
@@ -63,10 +63,9 @@ class FlutterSecureStorageWeb extends FlutterSecureStoragePlatform {
     }
   }
 
-  /// Encrypts and saves the [key] with the given [value].
+  /// Reads and decrypts the value for the given [key].
   ///
-  /// If the key was already in the storage, its associated value is changed.
-  /// If the value is null, deletes associated value for the given [key].
+  /// Returns null if the key does not exist or if decryption fails.
   @override
   Future<String?> read({
     required String key,
@@ -74,7 +73,16 @@ class FlutterSecureStorageWeb extends FlutterSecureStoragePlatform {
   }) async {
     final value = web.window.localStorage["${options[_publicKey]!}.$key"];
 
-    return _decryptValue(value, options);
+    if (value == null) {
+      return null;
+    }
+
+    try {
+      return await _decryptValue(value, options);
+    } catch (e) {
+      print("Error decrypting value: $e");
+      return null;
+    }
   }
 
   /// Decrypts and returns all keys with associated values.
@@ -258,13 +266,6 @@ class FlutterSecureStorageWeb extends FlutterSecureStoragePlatform {
 
     return plainText;
   }
-
-// @override
-// Future<bool> isCupertinoProtectedDataAvailable() => Future.value(false);
-//
-// @override
-// Stream<bool> get onCupertinoProtectedDataAvailabilityChanged =>
-//     Stream.empty();
 }
 
 extension on List<String> {


### PR DESCRIPTION
This PR addresses the issue #761 where a "Null check operator used on a null value" error occurs when accessing the storage through an IP address on a local network.

Changes made:
- Modified the `read` method in `FlutterSecureStorageWeb` to handle potential null values more safely
- Added null check before attempting to decrypt values
- Implemented error handling for the decryption process