### PR TITLE
[iOS] Use serial queue for execution of iOS keychain operations

### DIFF
--- a/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
+++ b/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
@@ -12,6 +12,7 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
 
     private let flutterSecureStorageManager: FlutterSecureStorage = FlutterSecureStorage()
     private var secStoreAvailabilitySink: FlutterEventSink?
+    private let serialExecutionQueue = DispatchQueue(label: "flutter_secure_storage_service")
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "plugins.it_nomads.com/flutter_secure_storage", binaryMessenger: registrar.messenger())
@@ -29,7 +30,7 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
             }
         }
 
-        DispatchQueue.global(qos: .userInitiated).async {
+        serialExecutionQueue.async {
             switch (call.method) {
             case "read":
                 self.read(call, handleResult)


### PR DESCRIPTION
**Reason:**
For iOS Keychain write function checks for existence of an item before performing changes, then it either:
- adds new item (if item for key does not exist)
- updates item if it exists

This makes write not an atomic operation on the storage. For performing operation we are using `DispatchQueue.global(qos: .userInitiated)`, which returns concurrent queue. In case two concurrent writings happening on the same key, one of these may fail - checks for existence of entry for key, entry does not exist yet, tries to add new entry, but in the meantime concurrent write stores the entry and the add fails.

**Change:**
This PR changes DispatchQueue used for executing iOS Keychain operations: Use serial queue instead of concurrent for execution of iOS keychain operations to avoid concurrent writing issues.

**Background:**
Before this plugin was using main DispatchQueue, which was serial as well, but it is suggested by Apple documentation not to use main Thread to avoid blocking of the UI. For details see this PR: #536 