### PR TITLE
feat: add JSON serialization to support storing various data types in FlutterSecureStorage

### DIFF
--- a/flutter_secure_storage/lib/test/test_flutter_secure_storage.dart
+++ b/flutter_secure_storage/lib/test/test_flutter_secure_storage.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+void main() {
+  group('FlutterSecureStorage Tests', () {
+    late FlutterSecureStorage storage;
+
+    setUp(() {
+      // Initialize the storage and set mock initial values
+      storage = const FlutterSecureStorage();
+      FlutterSecureStorage.setMockInitialValues({});
+    });
+
+    tearDown(() {
+      storage.unregisterAllListeners();
+    });
+
+    test('Write and read an int value', () async {
+      await storage.write(key: 'intKey', value: 42);
+      final result = await storage.read(key: 'intKey');
+      expect(result, equals(42));
+    });
+
+    test('Write and read a double value', () async {
+      await storage.write(key: 'doubleKey', value: 3.14);
+      final result = await storage.read(key: 'doubleKey');
+      expect(result, equals(3.14));
+    });
+
+    test('Write and read a String value', () async {
+      await storage.write(key: 'stringKey', value: 'Hello, World!');
+      final result = await storage.read(key: 'stringKey');
+      expect(result, equals('Hello, World!'));
+    });
+
+    test('Write and read a bool value', () async {
+      await storage.write(key: 'boolKey', value: true);
+      final result = await storage.read(key: 'boolKey');
+      expect(result, equals(true));
+    });
+
+    test('Write and read a List value', () async {
+      await storage.write(key: 'listKey', value: [1, 2, 3]);
+      final result = await storage.read(key: 'listKey');
+      expect(result, equals([1, 2, 3]));
+    });
+
+    test('Write and read a Map value', () async {
+      await storage.write(key: 'mapKey', value: {'a': 1, 'b': 2});
+      final result = await storage.read(key: 'mapKey');
+      expect(result, equals({'a': 1, 'b': 2}));
+    });
+
+    test('Ensure backward compatibility with plain strings', () async {
+      // Simulate existing data stored as a plain string
+      FlutterSecureStorage.setMockInitialValues({'plainKey': 'plainValue'});
+      final result = await storage.read(key: 'plainKey');
+      expect(result, equals('plainValue'));
+    });
+
+    test('Delete a value', () async {
+      await storage.write(key: 'deleteKey', value: 'toBeDeleted');
+      await storage.delete(key: 'deleteKey');
+      final result = await storage.read(key: 'deleteKey');
+      expect(result, isNull);
+    });
+
+    test('Read all values', () async {
+      await storage.write(key: 'intKey', value: 42);
+      await storage.write(key: 'stringKey', value: 'Hello');
+
+      final allValues = await storage.readAll();
+      expect(allValues['intKey'], equals(42));
+      expect(allValues['stringKey'], equals('Hello'));
+    });
+
+    test('Listener is called on value change', () async {
+      dynamic listenerValue;
+      storage.registerListener(
+        key: 'testKey',
+        listener: (value) {
+          listenerValue = value;
+        },
+      );
+
+      await storage.write(key: 'testKey', value: 'newValue');
+      expect(listenerValue, equals('newValue'));
+
+      await storage.delete(key: 'testKey');
+      expect(listenerValue, isNull);
+    });
+
+    test('Write and read null value', () async {
+      await storage.write(key: 'nullKey', value: null);
+      final result = await storage.read(key: 'nullKey');
+      expect(result, isNull);
+    });
+
+    test('Attempt to read non-existent key', () async {
+      final result = await storage.read(key: 'nonExistentKey');
+      expect(result, isNull);
+    });
+
+    test('Contains key test', () async {
+      await storage.write(key: 'existsKey', value: 'I exist');
+      final exists = await storage.containsKey(key: 'existsKey');
+      expect(exists, isTrue);
+
+      final notExists = await storage.containsKey(key: 'noKey');
+      expect(notExists, isFalse);
+    });
+
+    test('Delete all values', () async {
+      await storage.write(key: 'key1', value: 'value1');
+      await storage.write(key: 'key2', value: 'value2');
+
+      await storage.deleteAll();
+
+      final allValues = await storage.readAll();
+      expect(allValues, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
### **Pull Request (PR) Description:**

**Problem:**

The `flutter_secure_storage` package currently supports only `String` values for storage. This limitation requires developers to manually serialize and deserialize other data types, adding extra overhead and potential for errors.

**Solution:**

This PR enhances `flutter_secure_storage` by adding internal JSON serialization and deserialization, allowing developers to store and retrieve various data types (e.g., `int`, `double`, `bool`, `List`, `Map`) without manual conversion. The changes include:

- **`write` Method:**
  - Modified to accept a `dynamic` `value` parameter.
  - Serializes the `value` to a JSON string using `jsonEncode` before storing.
  
- **`read` Method:**
  - Modified to return a `Future<dynamic>` instead of `Future<String?>`.
  - Deserializes the stored JSON string back to its original data type using `jsonDecode`.
  - Handles non-JSON strings for backward compatibility by returning the string as is if deserialization fails.

- **Listeners:**
  - Updated to handle `dynamic` values instead of `String?`.

- **`readAll` Method:**
  - Modified to deserialize all stored values from JSON strings to their original data types.

- **Testing:**
  - Updated `setMockInitialValues` to accept `Map<String, dynamic>` and serialize values to JSON strings.
  - Added comprehensive tests to cover the new functionality and ensure backward compatibility.

**Backward Compatibility:**

- Existing code that uses `String` values will continue to work without modification.
- The `read` method now returns `dynamic` instead of `String?`. Developers may need to handle different data types when retrieving values.
- Non-JSON strings stored previously will be returned as `String` to maintain compatibility.

**Usage Example:**

```dart
final storage = FlutterSecureStorage();

// Writing different data types
await storage.write(key: 'intKey', value: 42);
await storage.write(key: 'doubleKey', value: 3.14);
await storage.write(key: 'stringKey', value: 'Hello, World!');
await storage.write(key: 'boolKey', value: true);
await storage.write(key: 'listKey', value: [1, 2, 3]);
await storage.write(key: 'mapKey', value: {'a': 1, 'b': 2});

// Reading the values back
int intValue = await storage.read(key: 'intKey');
double doubleValue = await storage.read(key: 'doubleKey');
String stringValue = await storage.read(key: 'stringKey');
bool boolValue = await storage.read(key: 'boolKey');
List<dynamic> listValue = await storage.read(key: 'listKey');
Map<String, dynamic> mapValue = await storage.read(key: 'mapKey');
```

**Tests:**

- Wrote new test cases covering:
  - Writing and reading various data types.
  - Backward compatibility with existing `String` values.
  - Edge cases (e.g., `null` values, non-existent keys).
  - Listener functionality with `dynamic` values.

**Potential Issues:**

- **Breaking Change:** Changing the return type of the `read` method from `Future<String?>` to `Future<dynamic>` may affect existing codebases that expect a `String` return type.
  - **Mitigation:** Developers may need to update their code to handle `dynamic` types or explicitly cast the result to `String`.

