### PR TITLE
Reintroduce deprecation warning supression.

### DIFF
--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/crypto/MasterKey.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/crypto/MasterKey.java
@@ -276,6 +276,7 @@ public final class MasterKey {
             static String getKeystoreAlias(KeyGenParameterSpec keyGenParameterSpec) {
                 return keyGenParameterSpec.getKeystoreAlias();
             }
+            @SuppressWarnings("deprecation")
             static MasterKey build(Builder builder) throws GeneralSecurityException, IOException {
                 if (builder.mKeyScheme == null && builder.mKeyGenParameterSpec == null) {
                     throw new IllegalArgumentException("build() called before "


### PR DESCRIPTION
Fixes #855 for now.

Maybe in the future we could migrate the code like [explained here](https://stackoverflow.com/a/66067487/4593433). But I would have to look into this more thoroughly, in order to not accidentially increase the minSdkLevel.