### PR TITLE
fix: remove warning on privacy manifest

### DIFF
--- a/flutter_secure_storage_darwin/CHANGELOG.md
+++ b/flutter_secure_storage_darwin/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.1
+ - Fix warnings with Privacy Manifest
+
 ## 0.1.0
 This package combines flutter_secure_storage_macos together with the ios part of flutter_secure_storage.
 

--- a/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin.podspec
+++ b/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin.podspec
@@ -12,7 +12,7 @@ A Flutter plugin to store data in secure storage.
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'German Saprykin' => 'saprykin.h@gmail.com' }
   s.source           = { :path => '.' }
-  s.source_files = 'flutter_secure_storage_darwin/Sources/flutter_secure_storage_darwin/**/*'
+  s.source_files = 'flutter_secure_storage_darwin/Sources/flutter_secure_storage_darwin/**/*.swift'
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '12.0'

--- a/flutter_secure_storage_darwin/pubspec.yaml
+++ b/flutter_secure_storage_darwin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_secure_storage_darwin
 description: "Apple (ios and macos) implementation of flutter_secure_storage"
-version: 0.1.0
+version: 0.1.1
 homepage: https://github.com/juliansteenbakker/flutter_secure_storage
 
 environment:


### PR DESCRIPTION
This PR fixed warning
```
warning: no rule to process file '.../PrivacyInfo.xcprivacy' of type 'text.xml' for architecture 'arm64' (in target 'flutter_secure_storage_darwin' from project 'Pods')
warning: no rule to process file '.../PrivacyInfo.xcprivacy' of type 'text.xml' for architecture 'x86_64' (in target 'flutter_secure_storage_darwin' from project 'Pods')
```