### PR TITLE
[Android] Optimize Secure Storage by Replacing Single Worker Thread with Thread Pool

### DIFF
--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -28,7 +28,8 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
     @Override
     public void onAttachedToEngine(FlutterPluginBinding binding) {
         this.binding = binding;
-        int threadCount = Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
+        int availableCores = Runtime.getRuntime().availableProcessors();
+        int threadCount = Math.min(4, Math.max(2, availableCores));
         this.executor = Executors.newFixedThreadPool(threadCount);
 
         channel = new MethodChannel(binding.getBinaryMessenger(), "plugins.it_nomads.com/flutter_secure_storage");


### PR DESCRIPTION
### Problem
Secure storage operations were previously executed on a single worker thread. This becomes a bottleneck when multiple read operations are triggered simultaneously, leading to significant delays due to the synchronous execution on the native side.

### Solution
Replaced the single worker thread with a thread pool (using Executors.newCachedThreadPool()). This allows multiple secure storage operations to run concurrently, significantly improving performance when handling simultaneous read/write requests.

### Impact
Reduces contention and latency for secure storage operations.
Improves app responsiveness when multiple storage operations are triggered.
No changes in API usage—just an internal optimization for Android.