### PR TITLE
docs(linux): replace ksecretsservice with kwalletmanager in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ parts:
       - libjsoncpp-dev
 ```
 
-Apart from `libsecret` you also need a keyring service, for that you need either `gnome-keyring` (for Gnome users) or `ksecretsservice` (for KDE users) or other light provider like [`secret-service`](https://github.com/yousefvand/secret-service).
+Apart from `libsecret` you also need a keyring service, for that you need either [`gnome-keyring`](https://wiki.gnome.org/Projects/GnomeKeyring) (for Gnome users) or [`kwalletmanager`](https://wiki.archlinux.org/title/KDE_Wallet) (for KDE users) or other light provider like [`secret-service`](https://github.com/yousefvand/secret-service).
 
 ## Integration Tests
 


### PR DESCRIPTION
The package [`ksecretsservice` is no longer maintained](https://github.com/KDE/ksecrets) since 2020. However, [KDE wallet supports `org.freedesktop.secrets` DBus API and can now be used by `libsecret`](https://wiki.archlinux.org/title/KDE_Wallet) for storing and retrieving secrets. Without updating the reference to the new package name, some developers will think `flutter_secure_storage` uses discounted dependencies that will cause issues on the long-term for KDE, especially if KDE support is a priority when it works as expected. We could also consider clarifying that it supports both `kwalletmanager` and `ksecretsservice`.

Optionally, we could clarify which packages are installed by default on specific distros or desktop environments. For example, `libsecret` is always installed on Fedora KDE and cannot be removed, and KDE wallet is also supported in this case.
