### PR TITLE
chore: update minSdkVersion from 23 to 24

### DIFF
--- a/.github/workflows/code-integration.yml
+++ b/.github/workflows/code-integration.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [ 23, 35 ]
+        api-level: [ 24, 35 ]
         target: [ default ]
     timeout-minutes: 30
     steps:

--- a/flutter_secure_storage/android/build.gradle
+++ b/flutter_secure_storage/android/build.gradle
@@ -38,7 +38,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 24
     }
     
 }

--- a/flutter_secure_storage/example/android/app/build.gradle.kts
+++ b/flutter_secure_storage/example/android/app/build.gradle.kts
@@ -44,7 +44,7 @@ android {
 
     defaultConfig {
         applicationId = "com.it_nomads.fluttersecurestorageexample"
-        minSdk = 23
+        minSdk = 24
         targetSdk = 35
         versionCode = flutterVersionCode.toInt()
         versionName = flutterVersionName


### PR DESCRIPTION
Update the minimum SDK version requirement across Android build configurations and CI workflow to 24 to align with new platform requirements