### PR TITLE
Fix: Handle Keystore exceptions on iMin devices

### DIFF
--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/crypto/MasterKey.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/crypto/MasterKey.java
@@ -314,8 +314,37 @@ public final class MasterKey {
                     throw new NullPointerException(
                             "KeyGenParameterSpec was null after build() check");
                 }
-                String keyAlias = MasterKeys.getOrCreate(builder.mKeyGenParameterSpec);
-                return new MasterKey(keyAlias, builder.mKeyGenParameterSpec);
+                try {
+                    String keyAlias = MasterKeys.getOrCreate(builder.mKeyGenParameterSpec);
+                    return new MasterKey(keyAlias, builder.mKeyGenParameterSpec);
+                } catch (GeneralSecurityException e) {
+                    if (builder.mKeyGenParameterSpec.getKeySize() == 256) {
+                        try {
+                            KeyGenParameterSpec.Builder newSpecBuilder = new KeyGenParameterSpec.Builder(
+                                    builder.mKeyGenParameterSpec.getKeystoreAlias(),
+                                    builder.mKeyGenParameterSpec.getPurposes())
+                                    .setBlockModes(builder.mKeyGenParameterSpec.getBlockModes())
+                                    .setEncryptionPaddings(builder.mKeyGenParameterSpec.getEncryptionPaddings())
+                                    .setKeySize(128);
+                            if (builder.mKeyGenParameterSpec.isUserAuthenticationRequired()) {
+                                newSpecBuilder.setUserAuthenticationRequired(true);
+                                newSpecBuilder.setUserAuthenticationValidityDurationSeconds(
+                                        builder.mKeyGenParameterSpec.getUserAuthenticationValidityDurationSeconds());
+                            }
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                                if (Api28Impl.isStrongBoxBacked(builder.mKeyGenParameterSpec)) {
+                                    Api28Impl.setIsStrongBoxBacked(newSpecBuilder);
+                                }
+                            }
+                            builder.mKeyGenParameterSpec = newSpecBuilder.build();
+                            String keyAlias = MasterKeys.getOrCreate(builder.mKeyGenParameterSpec);
+                            return new MasterKey(keyAlias, builder.mKeyGenParameterSpec);
+                        } catch (Exception fallbackException) {
+                            throw e;
+                        }
+                    }
+                    throw e;
+                }
             }
             @RequiresApi(28)
             static class Api28Impl {

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/crypto/MasterKeys.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/crypto/MasterKeys.java
@@ -60,9 +60,9 @@ public final class MasterKeys {
     }
     @VisibleForTesting
     static void validate(KeyGenParameterSpec spec) {
-        if (spec.getKeySize() != KEY_SIZE) {
+        if (spec.getKeySize() != 256 && spec.getKeySize() != 128) {
             throw new IllegalArgumentException(
-                    "invalid key size, want " + KEY_SIZE + " bits got " + spec.getKeySize()
+                    "invalid key size, want 256 or 128 bits got " + spec.getKeySize()
                             + " bits");
         }
         if (!Arrays.equals(spec.getBlockModes(), new String[]{KeyProperties.BLOCK_MODE_GCM})) {


### PR DESCRIPTION
This change addresses a `GeneralSecurityException: Keystore operation failed` error that occurs on certain devices, notably the iMin POS running Android 10.

The root cause appears to be a device-specific bug in the Android KeyStore implementation that prevents the generation of a standard 256-bit AES key.

To resolve this, a fallback mechanism has been implemented. If the initial attempt to create a 256-bit master key fails, the code will now automatically retry the operation with a 128-bit key. This provides a workaround for the affected devices without altering the behavior for devices that correctly support 256-bit keys.