### PR TITLE
Explain the underscore being added automatically to the prefix

### DIFF
--- a/flutter_secure_storage/lib/options/android_options.dart
+++ b/flutter_secure_storage/lib/options/android_options.dart
@@ -64,8 +64,10 @@ class AndroidOptions extends Options {
   final String? sharedPreferencesName;
 
   /// The prefix for a shared preference key. The prefix is used to make sure
-  /// the key is unique to your application. If not provided, a default prefix
-  /// will be used.
+  /// the key is unique to your application. An underscore (_) is added to the end of the prefix automatically. 
+  /// If not provided, a default prefix will be used.
+  /// 
+  /// Example: preferencesKeyPrefix: "my_app" will result in a key like "my_app_key1".
   ///
   /// WARNING: If you change this you can't retrieve already saved preferences.
   final String? preferencesKeyPrefix;


### PR DESCRIPTION
I've spent around 3hrs wondering why I cannot read the value from the storage on the Kotlin side, only to discover that the prefix is actually not a complete prefix, there is also an underscore. This should be noted in the docs.