### PR TITLE
refactor keychain deletion logic for completeness (fix issue #1011)

### DIFF
--- a/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin/Sources/flutter_secure_storage_darwin/FlutterSecureStorage.swift
+++ b/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin/Sources/flutter_secure_storage_darwin/FlutterSecureStorage.swift
@@ -338,26 +338,57 @@ class FlutterSecureStorage {
 
     /// Deletes an item from the keychain.
     internal func delete(params: KeychainQueryParameters) -> FlutterSecureStorageResponse {
-        let query = baseQuery(from: params)
-        let status = SecItemDelete(query as CFDictionary)
-        // Return nil if nothing is found
-        if (status == errSecItemNotFound) {
-            return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
-        }
-        return FlutterSecureStorageResponse(status: status, value: nil)
+        return performDelete(params: params, clearKey: false)
     }
 
     /// Deletes all items matching the query parameters.
     internal func deleteAll(params: KeychainQueryParameters) -> FlutterSecureStorageResponse {
-        let query = baseQuery(from: params)
-        let status = SecItemDelete(query as CFDictionary)
-        // Return nil if nothing is found
-        if (status == errSecItemNotFound) {
-            return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
-        }
-        return FlutterSecureStorageResponse(status: status, value: nil)
+        return performDelete(params: params, clearKey: true)
     }
     
+    /// Private helper method to perform keychain deletion.
+    /// Attempts to delete items with both synchronizable states and without accessibility constraints
+    /// to ensure complete removal regardless of how items were originally stored.
+    ///
+    /// - Parameters:
+    ///   - params: The keychain query parameters
+    ///   - clearKey: If true, removes the key constraint to delete all items; if false, deletes specific key
+    /// - Returns: Response indicating success or failure of the deletion operation
+    private func performDelete(params: KeychainQueryParameters, clearKey: Bool) -> FlutterSecureStorageResponse {
+        func deleteFromKeychain(withSynchronizable synchronizable: Bool?) -> OSStatus {
+            var modifiedParams = params
+
+            if clearKey {
+                modifiedParams.key = nil
+            }
+
+            modifiedParams.isSynchronizable = synchronizable
+            modifiedParams.accessibilityLevel = nil
+            modifiedParams.accessControlFlags = nil
+
+            let query = baseQuery(from: modifiedParams)
+            return SecItemDelete(query as CFDictionary)
+        }
+
+        let statusSync = deleteFromKeychain(withSynchronizable: true)
+        let statusNonSync = deleteFromKeychain(withSynchronizable: false)
+        
+        // Return success if both operations report item not found
+        if statusSync == errSecItemNotFound && statusNonSync == errSecItemNotFound {
+            return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
+        }
+
+        // Return success if either operation succeeded
+        if statusSync == errSecSuccess || statusNonSync == errSecSuccess {
+            return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
+        }
+
+        // Return the first error encountered
+        let status = statusSync != errSecItemNotFound ? statusSync : statusNonSync
+
+        return FlutterSecureStorageResponse(status: status, value: nil)
+    }
+
     internal func getPersistentReference(params: KeychainQueryParameters) -> FlutterSecureStorageResponse {
         var query = baseQuery(from: params)
         query[kSecReturnPersistentRef] = true


### PR DESCRIPTION
This pull request refactors the deletion logic for keychain items in `FlutterSecureStorage.swift` to improve reliability and code maintainability. The main change is the introduction of a new private helper method to handle deletions, ensuring items are removed regardless of their synchronizable state or accessibility constraints.

Keychain deletion logic improvements:

* Introduced a new private method `performDelete` to centralize and streamline the deletion process for both single and bulk keychain item removal. 
* Updated the `delete` and `deleteAll` methods to use the new `performDelete` helper, reducing code duplication and improving clarity. 
* Enhanced deletion reliability by attempting to delete items with both synchronizable states and without accessibility constraints, ensuring complete removal regardless of how items were originally stored. 