### PR TITLE
docs(AndroidOptions): clarify resetOnError default value and fix typo

### DIFF
--- a/flutter_secure_storage/lib/options/android_options.dart
+++ b/flutter_secure_storage/lib/options/android_options.dart
@@ -99,9 +99,9 @@ class AndroidOptions extends Options {
 
   /// When an error is detected, automatically reset all data. This will prevent
   /// fatal errors regarding an unknown key however keep in mind that it will
-  /// PERMANENLTY erase the data when an error occurs.
+  /// PERMANENTLY erase the data when an error occurs.
   ///
-  /// Defaults to false.
+  /// Defaults to true.
   final bool _resetOnError;
 
   /// When the encryption algorithm changes, automatically migrate existing data


### PR DESCRIPTION
- Update the `_resetOnError` comment from "Defaults to false" to "Defaults to true" to reflect the behavior introduced in [v10.0.0 release](https://github.com/juliansteenbakker/flutter_secure_storage/releases/tag/v10.0.0).
- Also fix typo `PERMANENLTY` -> `PERMANENTLY`

Closes #1027