### PR TITLE
[WIP] fix(android): isolate storage instances per shared preferences name (fix: #1023)

### DIFF
--- a/flutter_secure_storage/README.md
+++ b/flutter_secure_storage/README.md
@@ -168,6 +168,21 @@ For advanced users, all combinations below are supported using the `AndroidOptio
     - `false`: Gracefully degrades if biometrics unavailable
     - `true`: Strictly requires device security (PIN/pattern/biometric), throws exception if unavailable
 
+##### Multiple storage namespaces (Android)
+
+If you need multiple isolated secure storages (for example, per signed-in user), set `sharedPreferencesName` via `AndroidOptions`:
+
+```dart
+final storageA = FlutterSecureStorage(
+  aOptions: AndroidOptions(sharedPreferencesName: 'namespace_a'),
+);
+final storageB = FlutterSecureStorage(
+  aOptions: AndroidOptions(sharedPreferencesName: 'namespace_b'),
+);
+```
+
+On Android, `FlutterSecureStorage` keeps some migration/cipher metadata in a global configuration preferences file (not namespaced). The actual stored values are isolated by `sharedPreferencesName`.
+
 #### Biometric Authentication
 
 Flutter Secure Storage supports biometric authentication (fingerprint, face recognition, etc.) on Android API 23+.

--- a/flutter_secure_storage/README.md
+++ b/flutter_secure_storage/README.md
@@ -168,21 +168,6 @@ For advanced users, all combinations below are supported using the `AndroidOptio
     - `false`: Gracefully degrades if biometrics unavailable
     - `true`: Strictly requires device security (PIN/pattern/biometric), throws exception if unavailable
 
-##### Multiple storage namespaces (Android)
-
-If you need multiple isolated secure storages (for example, per signed-in user), set `sharedPreferencesName` via `AndroidOptions`:
-
-```dart
-final storageA = FlutterSecureStorage(
-  aOptions: AndroidOptions(sharedPreferencesName: 'namespace_a'),
-);
-final storageB = FlutterSecureStorage(
-  aOptions: AndroidOptions(sharedPreferencesName: 'namespace_b'),
-);
-```
-
-On Android, `FlutterSecureStorage` keeps some migration/cipher metadata in a global configuration preferences file (not namespaced). The actual stored values are isolated by `sharedPreferencesName`.
-
 #### Biometric Authentication
 
 Flutter Secure Storage supports biometric authentication (fingerprint, face recognition, etc.) on Android API 23+.

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
@@ -35,6 +35,10 @@ public class FlutterSecureStorage {
 
     private static final String TAG = "FlutterSecureStorage";
     private static final Charset charset = StandardCharsets.UTF_8;
+    // NOTE: This config store is global (not namespaced by sharedPreferencesName).
+    // It holds migration/cipher markers that apply process-wide, even when the app uses
+    // multiple FlutterSecureStorage namespaces via AndroidOptions.sharedPreferencesName.
+    // This is a documented limitation; namespace isolation is handled by the plugin routing.
     private static final String SHARED_PREFERENCES_CONFIG_NAME = "FlutterSecureStorageConfiguration";
 
     private FlutterSecureStorageConfig config;

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
@@ -32,15 +32,9 @@ import java.util.concurrent.Executors;
 import javax.crypto.Cipher;
 
 public class FlutterSecureStorage {
-
     private static final String TAG = "FlutterSecureStorage";
     private static final Charset charset = StandardCharsets.UTF_8;
-    // NOTE: This config store is global (not namespaced by sharedPreferencesName).
-    // It holds migration/cipher markers that apply process-wide, even when the app uses
-    // multiple FlutterSecureStorage namespaces via AndroidOptions.sharedPreferencesName.
-    // This is a documented limitation; namespace isolation is handled by the plugin routing.
-    private static final String SHARED_PREFERENCES_CONFIG_NAME = "FlutterSecureStorageConfiguration";
-
+    
     private FlutterSecureStorageConfig config;
     @NonNull
     private final Context context;
@@ -161,10 +155,8 @@ public class FlutterSecureStorage {
                 Context.MODE_PRIVATE
         );
 
-        SharedPreferences configSource = context.getSharedPreferences(
-                SHARED_PREFERENCES_CONFIG_NAME,
-                Context.MODE_PRIVATE
-        );
+        // Use namespaced config with legacy fallback for backwards compatibility
+        NamespacedConfigSource configSource = new NamespacedConfigSource(context, config.getSharedPreferencesName());
 
         Boolean isAlreadyMigrated = getEncryptedPrefsMigrated(configSource);
 
@@ -263,7 +255,7 @@ public class FlutterSecureStorage {
         }
     }
 
-    private void initializeStorageCipher(SharedPreferences configSource, SecurePreferencesCallback<Void> callback) {
+    private void initializeStorageCipher(NamespacedConfigSource configSource, SecurePreferencesCallback<Void> callback) {
         try {
             storageCipherFactory = new StorageCipherFactory(configSource, config.getPrefOptionKeyCipherAlgorithm(), config.getPrefOptionStorageCipherAlgorithm(), config);
 
@@ -339,7 +331,7 @@ public class FlutterSecureStorage {
      * @param dataSource SharedPreferences containing encrypted data
      * @param callback Callback to notify of success/failure
      */
-    private void migrateData(SharedPreferences configSource, SharedPreferences dataSource,
+    private void migrateData(NamespacedConfigSource configSource, SharedPreferences dataSource,
                             SecurePreferencesCallback<Void> callback) {
         Log.i(TAG, "Starting data migration from saved to current cipher algorithms...");
 
@@ -444,7 +436,7 @@ public class FlutterSecureStorage {
      * @param dataSource SharedPreferences containing encrypted data
      * @param callback Callback to notify of success/failure
      */
-    private void migrateNonBiometric(SharedPreferences configSource, SharedPreferences dataSource,
+    private void migrateNonBiometric(NamespacedConfigSource configSource, SharedPreferences dataSource,
                                     SecurePreferencesCallback<Void> callback) {
         Log.i(TAG, "Starting non-biometric migration (no authentication required)...");
 
@@ -503,7 +495,7 @@ public class FlutterSecureStorage {
     /**
      * Updates algorithm markers in config to match current cipher algorithms.
      */
-    private void updateAlgorithmMarkers(SharedPreferences configSource) {
+    private void updateAlgorithmMarkers(NamespacedConfigSource configSource) {
         SharedPreferences.Editor editor = configSource.edit();
         storageCipherFactory.storeCurrentAlgorithms(editor);
         editor.commit();
@@ -523,7 +515,7 @@ public class FlutterSecureStorage {
      * @param toBiometric True if migrating TO a biometric algorithm
      * @param callback Callback to notify of success/failure
      */
-    private void migrateBiometric(SharedPreferences configSource, SharedPreferences dataSource,
+    private void migrateBiometric(NamespacedConfigSource configSource, SharedPreferences dataSource,
                                  boolean fromBiometric, boolean toBiometric,
                                  SecurePreferencesCallback<Void> callback) {
         Log.i(TAG, "Starting biometric migration (authentication required)...");
@@ -550,7 +542,7 @@ public class FlutterSecureStorage {
      * Migrates FROM biometric → TO non-biometric.
      * Requires authentication with OLD biometric cipher to decrypt.
      */
-    private void migrateFromBiometricToNonBiometric(SharedPreferences configSource, SharedPreferences dataSource,
+    private void migrateFromBiometricToNonBiometric(NamespacedConfigSource configSource, SharedPreferences dataSource,
                                                     SecurePreferencesCallback<Void> callback) {
         try {
             // Step 1: Get OLD biometric cipher (requires authentication)
@@ -628,7 +620,7 @@ public class FlutterSecureStorage {
      * Migrates FROM non-biometric → TO biometric.
      * Requires authentication with NEW biometric cipher to encrypt.
      */
-    private void migrateFromNonBiometricToBiometric(SharedPreferences configSource, SharedPreferences dataSource,
+    private void migrateFromNonBiometricToBiometric(NamespacedConfigSource configSource, SharedPreferences dataSource,
                                                     SecurePreferencesCallback<Void> callback) {
         try {
             // Step 1: Decrypt with OLD non-biometric cipher (no auth)
@@ -707,7 +699,7 @@ public class FlutterSecureStorage {
      * Migrates FROM biometric → TO biometric (changing biometric algorithms).
      * Requires authentication with both OLD and NEW biometric ciphers.
      */
-    private void migrateBiometricToBiometric(SharedPreferences configSource, SharedPreferences dataSource,
+    private void migrateBiometricToBiometric(NamespacedConfigSource configSource, SharedPreferences dataSource,
                                             SecurePreferencesCallback<Void> callback) {
         try {
             // Step 1: Get OLD biometric cipher
@@ -810,13 +802,13 @@ public class FlutterSecureStorage {
         }
     }
 
-    private void setEncryptedPrefsMigrated(SharedPreferences configSource) {
+    private void setEncryptedPrefsMigrated(NamespacedConfigSource configSource) {
         SharedPreferences.Editor editor = configSource.edit();
         editor.putBoolean("ENCRYPTED_PREFERENCES_MIGRATED", true);
         editor.commit();
     }
 
-    private Boolean getEncryptedPrefsMigrated(SharedPreferences configSource) {
+    private Boolean getEncryptedPrefsMigrated(NamespacedConfigSource configSource) {
         return configSource.getBoolean("ENCRYPTED_PREFERENCES_MIGRATED", false);
     }
 
@@ -829,7 +821,7 @@ public class FlutterSecureStorage {
      * @param exception The original exception (BadPaddingException, InvalidKeyException, etc.)
      * @param errorType Human-readable description of the error type
      */
-    private void handleKeyMismatch(SharedPreferences configSource, SecurePreferencesCallback<Void> callback,
+    private void handleKeyMismatch(NamespacedConfigSource configSource, SecurePreferencesCallback<Void> callback,
                                    Exception exception, String errorType) {
         Log.e(TAG, "Key mismatch detected during cipher initialization: " + errorType, exception);
         Log.e(TAG, "This typically occurs after an algorithm change.");
@@ -894,7 +886,7 @@ public class FlutterSecureStorage {
      * Deletes all encrypted data, keys, and algorithm markers, then reinitializes.
      * Extracted from handleKeyMismatch for reuse.
      */
-    private void deleteAllDataAndKeys(SharedPreferences configSource, SecurePreferencesCallback<Void> callback) {
+    private void deleteAllDataAndKeys(NamespacedConfigSource configSource, SecurePreferencesCallback<Void> callback) {
         try {
             // Delete keys from AndroidKeyStore
             try {

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -10,6 +10,7 @@ import androidx.annotation.NonNull;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.HashMap;
 import java.util.Map;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -23,13 +24,14 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
 
     private static final String TAG = "FlutterSecureStoragePlugin";
     private MethodChannel channel;
-    private FlutterSecureStorage secureStorage;
+    private Context applicationContext;
+    private final Map<String, FlutterSecureStorage> storagesBySharedPreferencesName = new HashMap<>();
     private HandlerThread workerThread;
     private Handler workerThreadHandler;
 
     public void initInstance(BinaryMessenger messenger, Context context) {
         try {
-            secureStorage = new FlutterSecureStorage(context);
+            applicationContext = context.getApplicationContext();
 
             workerThread = new HandlerThread("com.it_nomads.fluttersecurestorage.worker");
             workerThread.start();
@@ -56,7 +58,10 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
             channel.setMethodCallHandler(null);
             channel = null;
         }
-        secureStorage = null;
+        synchronized (storagesBySharedPreferencesName) {
+            storagesBySharedPreferencesName.clear();
+        }
+        applicationContext = null;
     }
 
     @Override
@@ -67,15 +72,30 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
     }
 
     @SuppressWarnings("unchecked")
-    private String getKeyFromCall(MethodCall call) {
+    private static String getKeyFromCall(MethodCall call) {
         Map<String, Object> arguments = (Map<String, Object>) call.arguments;
-        return secureStorage.addPrefixToKey((String) arguments.get("key"));
+        return (String) arguments.get("key");
     }
 
     @SuppressWarnings("unchecked")
-    private String getValueFromCall(MethodCall call) {
+    private static String getValueFromCall(MethodCall call) {
         Map<String, Object> arguments = (Map<String, Object>) call.arguments;
         return (String) arguments.get("value");
+    }
+
+    private FlutterSecureStorage getOrCreateStorage(FlutterSecureStorageConfig config) {
+        // Key by sharedPreferencesName only, matching AndroidOptions.sharedPreferencesName.
+        // Other config options (cipher algorithms, prefixes) are applied per call during initialize().
+        final String name = config.getSharedPreferencesName();
+        synchronized (storagesBySharedPreferencesName) {
+            FlutterSecureStorage existing = storagesBySharedPreferencesName.get(name);
+            if (existing != null) {
+                return existing;
+            }
+            FlutterSecureStorage created = new FlutterSecureStorage(applicationContext);
+            storagesBySharedPreferencesName.put(name, created);
+            return created;
+        }
     }
 
     /**
@@ -123,6 +143,7 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
         public void run() {
             Map<String, Object> options = (Map<String, Object>) ((Map<String, Object>) call.arguments).get("options");
             FlutterSecureStorageConfig config = new FlutterSecureStorageConfig(options);
+            FlutterSecureStorage secureStorage = getOrCreateStorage(config);
 
             secureStorage.initialize(config, new SecurePreferencesCallback<>() {
                 @Override
@@ -130,7 +151,7 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                     try {
                         switch (call.method) {
                             case "write": {
-                                String key = getKeyFromCall(call);
+                                String key = secureStorage.addPrefixToKey(getKeyFromCall(call));
                                 String value = getValueFromCall(call);
 
                                 if (value != null) {
@@ -142,7 +163,7 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                                 break;
                             }
                             case "read": {
-                                String key = getKeyFromCall(call);
+                                String key = secureStorage.addPrefixToKey(getKeyFromCall(call));
 
                                 if (secureStorage.containsKey(key)) {
                                     String value = secureStorage.read(key);
@@ -157,14 +178,14 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                                 break;
                             }
                             case "containsKey": {
-                                String key = getKeyFromCall(call);
+                                String key = secureStorage.addPrefixToKey(getKeyFromCall(call));
 
                                 boolean containsKey = secureStorage.containsKey(key);
                                 result.success(containsKey);
                                 break;
                             }
                             case "delete": {
-                                String key = getKeyFromCall(call);
+                                String key = secureStorage.addPrefixToKey(getKeyFromCall(call));
 
                                 secureStorage.delete(key);
                                 result.success(null);

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -72,9 +72,10 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
     }
 
     @SuppressWarnings("unchecked")
-    private static String getKeyFromCall(MethodCall call) {
+    private static String getKeyFromCall(FlutterSecureStorage storage, MethodCall call) {
         Map<String, Object> arguments = (Map<String, Object>) call.arguments;
-        return (String) arguments.get("key");
+        String key = (String) arguments.get("key");
+        return storage.addPrefixToKey(key);
     }
 
     @SuppressWarnings("unchecked")
@@ -85,7 +86,6 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
 
     private FlutterSecureStorage getOrCreateStorage(FlutterSecureStorageConfig config) {
         // Key by sharedPreferencesName only, matching AndroidOptions.sharedPreferencesName.
-        // Other config options (cipher algorithms, prefixes) are applied per call during initialize().
         final String name = config.getSharedPreferencesName();
         synchronized (storagesBySharedPreferencesName) {
             FlutterSecureStorage existing = storagesBySharedPreferencesName.get(name);
@@ -151,7 +151,7 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                     try {
                         switch (call.method) {
                             case "write": {
-                                String key = secureStorage.addPrefixToKey(getKeyFromCall(call));
+                                String key = getKeyFromCall(secureStorage, call);
                                 String value = getValueFromCall(call);
 
                                 if (value != null) {
@@ -163,7 +163,7 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                                 break;
                             }
                             case "read": {
-                                String key = secureStorage.addPrefixToKey(getKeyFromCall(call));
+                                String key = getKeyFromCall(secureStorage, call);
 
                                 if (secureStorage.containsKey(key)) {
                                     String value = secureStorage.read(key);
@@ -178,14 +178,14 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                                 break;
                             }
                             case "containsKey": {
-                                String key = secureStorage.addPrefixToKey(getKeyFromCall(call));
+                                String key = getKeyFromCall(secureStorage, call);
 
                                 boolean containsKey = secureStorage.containsKey(key);
                                 result.success(containsKey);
                                 break;
                             }
                             case "delete": {
-                                String key = secureStorage.addPrefixToKey(getKeyFromCall(call));
+                                String key = getKeyFromCall(secureStorage, call);
 
                                 secureStorage.delete(key);
                                 result.success(null);

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/NamespacedConfigSource.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/NamespacedConfigSource.java
@@ -1,0 +1,71 @@
+package com.it_nomads.fluttersecurestorage;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * Helper class that provides dual-read fallback for config SharedPreferences.
+ * Reads from namespaced config first, falls back to legacy global config if not found.
+ * Writes always go to the namespaced config.
+ */
+public class NamespacedConfigSource {
+    // Legacy global config name (used for backwards compatibility fallback reads only)
+    private static final String LEGACY_GLOBAL_CONFIG_NAME = "FlutterSecureStorageConfiguration";
+    
+    private final SharedPreferences namespacedConfig;
+    private final SharedPreferences legacyConfig;
+    
+    public NamespacedConfigSource(Context context, String sharedPreferencesName) {
+        String namespacedName = getNamespacedConfigPrefsName(sharedPreferencesName);
+        this.namespacedConfig = context.getSharedPreferences(namespacedName, Context.MODE_PRIVATE);
+        this.legacyConfig = context.getSharedPreferences(LEGACY_GLOBAL_CONFIG_NAME, Context.MODE_PRIVATE);
+    }
+    
+    /**
+     * Returns the namespaced config SharedPreferences name for a given sharedPreferencesName.
+     * Config markers (algorithm and migration flags) are now isolated per namespace.
+     * 
+     * @param sharedPreferencesName The namespace identifier
+     * @return Namespaced config prefs name
+     */
+    private static String getNamespacedConfigPrefsName(String sharedPreferencesName) {
+        // Use a delimiter to avoid collisions with legacy global name
+        return "FlutterSecureStorageConfiguration:" + sharedPreferencesName;
+    }
+    
+    /**
+     * Reads a string value with fallback: namespaced first, then legacy global.
+     */
+    public String getString(String key, String defaultValue) {
+        String value = namespacedConfig.getString(key, null);
+        if (value != null) {
+            return value;
+        }
+        return legacyConfig.getString(key, defaultValue);
+    }
+    
+    /**
+     * Reads a boolean value with fallback: namespaced first, then legacy global.
+     */
+    public boolean getBoolean(String key, boolean defaultValue) {
+        // Check if key exists in namespaced config (even if value is default)
+        if (namespacedConfig.contains(key)) {
+            return namespacedConfig.getBoolean(key, defaultValue);
+        }
+        return legacyConfig.getBoolean(key, defaultValue);
+    }
+    
+    /**
+     * Returns an editor for the namespaced config (writes always go to namespaced).
+     */
+    public SharedPreferences.Editor edit() {
+        return namespacedConfig.edit();
+    }
+    
+    /**
+     * Checks if a key exists in either namespaced or legacy config.
+     */
+    public boolean contains(String key) {
+        return namespacedConfig.contains(key) || legacyConfig.contains(key);
+    }
+}

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherFactory.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherFactory.java
@@ -5,6 +5,7 @@ import android.content.SharedPreferences;
 import android.os.Build;
 
 import com.it_nomads.fluttersecurestorage.FlutterSecureStorageConfig;
+import com.it_nomads.fluttersecurestorage.NamespacedConfigSource;
 
 import javax.crypto.Cipher;
 
@@ -21,7 +22,7 @@ public class StorageCipherFactory {
     private final StorageCipherAlgorithm currentStorageAlgorithm;
     private final FlutterSecureStorageConfig config;
 
-    public StorageCipherFactory(SharedPreferences configSource, String keyCipherAlgorithm, String storageCipherAlgorithm, FlutterSecureStorageConfig config) {
+    public StorageCipherFactory(NamespacedConfigSource configSource, String keyCipherAlgorithm, String storageCipherAlgorithm, FlutterSecureStorageConfig config) {
         this.config = config;
         final String savedKeyCipherAlgorithm = configSource.getString(ELEMENT_PREFERENCES_ALGORITHM_KEY, null);
         final String savedStorageCipherAlgorithm = configSource.getString(ELEMENT_PREFERENCES_ALGORITHM_STORAGE, null);

--- a/flutter_secure_storage/example/integration_test/app_test.dart
+++ b/flutter_secure_storage/example/integration_test/app_test.dart
@@ -47,9 +47,89 @@ void main() {
 
         // Assert
         final readA = await storageA.read(key: key);
-        expect(readA, equals(valueA),
-            reason:
-                'Deleting keys from namespace_b must not affect namespace_a');
+        expect(
+          readA,
+          equals(valueA),
+          reason:
+              'Deleting keys from namespace_b must not affect namespace_a',
+        );
+      },
+      skip: !Platform.isAndroid,
+    );
+
+    testWidgets(
+      'Android: namespaces with different cipher algorithms must not interfere '
+      '(config markers isolation)',
+      (WidgetTester tester) async {
+        // This test verifies that algorithm markers and migration flags are
+        // properly namespaced per sharedPreferencesName, preventing
+        // cross-namespace algorithm interference when different namespaces use
+        // different cipher algorithms.
+        final pageObject = await _setupHomePage(tester);
+        await pageObject.deleteAll();
+
+        // Use different algorithms per namespace to test isolation
+        const storageA = FlutterSecureStorage(
+          aOptions: AndroidOptions(
+            sharedPreferencesName: 'namespace_alg_a',
+            keyCipherAlgorithm: KeyCipherAlgorithm.RSA_ECB_PKCS1Padding,
+            storageCipherAlgorithm:
+                StorageCipherAlgorithm.AES_CBC_PKCS7Padding,
+          ),
+        );
+        const storageB = FlutterSecureStorage(
+          aOptions: AndroidOptions(
+            sharedPreferencesName: 'namespace_alg_b',
+            keyCipherAlgorithm:
+                KeyCipherAlgorithm.RSA_ECB_OAEPwithSHA_256andMGF1Padding,
+            storageCipherAlgorithm: StorageCipherAlgorithm.AES_GCM_NoPadding,
+          ),
+        );
+
+        const key = 'it_android_algorithm_isolation_key';
+        const valueA = 'value_algorithm_a';
+        const valueB = 'value_algorithm_b';
+
+        // Arrange: Write values to both namespaces with different algorithms
+        await storageA.write(key: key, value: valueA);
+        await storageB.write(key: key, value: valueB);
+
+        // Verify both can read their own values
+        expect(await storageA.read(key: key), equals(valueA));
+        expect(await storageB.read(key: key), equals(valueB));
+
+        // Act: Force re-initialization by reading again (triggers config
+        // marker checks). This simulates what happens when switching between
+        // namespaces.
+        final readA2 = await storageA.read(key: key);
+        final readB2 = await storageB.read(key: key);
+
+        // Assert: Both namespaces should still read their correct values.
+        // If config markers were shared, one namespace might try to decrypt
+        // with the wrong algorithm after the other namespace initializes.
+        expect(
+          readA2,
+          equals(valueA),
+          reason:
+              'Namespace A must read its value correctly even after '
+              'namespace B initializes with different algorithms',
+        );
+        expect(
+          readB2,
+          equals(valueB),
+          reason:
+              'Namespace B must read its value correctly even after '
+              'namespace A initializes with different algorithms',
+        );
+
+        // Additional verification: Write new values and read back
+        const newValueA = 'updated_value_a';
+        const newValueB = 'updated_value_b';
+        await storageA.write(key: key, value: newValueA);
+        await storageB.write(key: key, value: newValueB);
+
+        expect(await storageA.read(key: key), equals(newValueA));
+        expect(await storageB.read(key: key), equals(newValueB));
       },
       skip: !Platform.isAndroid,
     );

--- a/flutter_secure_storage/example/integration_test/app_test.dart
+++ b/flutter_secure_storage/example/integration_test/app_test.dart
@@ -10,6 +10,53 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   group('Secure Storage Tests', () {
+    testWidgets(
+      'Android: deleteAll() must not clear other '
+      'sharedPreferencesName namespace (regression #1023)',
+      (WidgetTester tester) async {
+        // This is a plugin-level regression test for:
+        // https://github.com/juliansteenbakker/flutter_secure_storage/issues/1023
+        //
+        // The Android implementation must isolate namespaces created via
+        // AndroidOptions.sharedPreferencesName. A deleteAll() issued against
+        // one
+        // namespace must not delete keys stored in another namespace.
+        final pageObject = await _setupHomePage(tester);
+
+        // Use the app's popup menu path to ensure the plugin is initialized and
+        // stable before we run the direct namespace assertions below.
+        await pageObject.deleteAll();
+
+        const storageA = FlutterSecureStorage(
+          aOptions: AndroidOptions(sharedPreferencesName: 'namespace_a'),
+        );
+        const storageB = FlutterSecureStorage(
+          aOptions: AndroidOptions(sharedPreferencesName: 'namespace_b'),
+        );
+
+        const key = 'it_android_namespace_key';
+        const valueA = 'value_a';
+        const valueB = 'value_b';
+
+        // Arrange
+        await storageA.write(key: key, value: valueA);
+        await storageB.write(key: key, value: valueB);
+
+        // Act
+        await storageB.deleteAll();
+
+        // Assert
+        final readA = await storageA.read(key: key);
+        expect(
+          readA,
+          equals(valueA),
+          reason: 'Deleting all keys from namespace_b must not affect '
+              'namespace_a.',
+        );
+      },
+      skip: !Platform.isAndroid,
+    );
+
     testWidgets('Add a Random Row', (WidgetTester tester) async {
       final pageObject = await _setupHomePage(tester);
       await pageObject.addRandomRow();

--- a/flutter_secure_storage/example/integration_test/app_test.dart
+++ b/flutter_secure_storage/example/integration_test/app_test.dart
@@ -47,12 +47,9 @@ void main() {
 
         // Assert
         final readA = await storageA.read(key: key);
-        expect(
-          readA,
-          equals(valueA),
-          reason: 'Deleting all keys from namespace_b must not affect '
-              'namespace_a.',
-        );
+        expect(readA, equals(valueA),
+            reason:
+                'Deleting keys from namespace_b must not affect namespace_a');
       },
       skip: !Platform.isAndroid,
     );


### PR DESCRIPTION
# Fix Android namespace isolation for `sharedPreferencesName`

Fixes #1023

## Problem

Multiple `FlutterSecureStorage` instances with different `sharedPreferences Name` values shared a single cached `FlutterSecureStorage` instance, causing `deleteAll()` and other operations to affect data across namespaces.

## Solution

Enforce namespace isolation at the plugin layer by routing each `MethodChannel` call to a dedicated `FlutterSecureStorage` instance per `sharedPreferencesName`. This ensures operations on namespace B never affect namespace A.

**Implementation:**

- Plugin maintains a `Map<String, FlutterSecureStorage>` keyed by `sharedPreferencesName`
- `getOrCreateStorage()` retrieves or creates the correct instance per namespace
- All operations (`read`, `write`, `delete`, `deleteAll`, etc.) use the namespace-specific instance

## Testing

✅ Added Android-only integration test that:

- Writes the same key to two namespaces (`namespace_a`, `namespace_b`)
- Calls `deleteAll()` on `namespace_b`
- Asserts the key in `namespace_a` remains intact

## Breaking Changes

None

## Notes

- `SHARED_PREFERENCES_CONFIG_NAME` remains global (stores migration/cipher metadata only). This poses a threat of possible encryption-related issues when two or more storages use different algorithms. 
- Actual stored values are fully isolated per `sharedPreferencesName`
- Matches iOS/macOS behavior where each operation uses namespace-specific parameters
