### PR TITLE
fix: align macOS options keys in darwin plugin

### DIFF
--- a/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin/Sources/flutter_secure_storage_darwin/FlutterSecureStorageDarwinPlugin.swift
+++ b/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin/Sources/flutter_secure_storage_darwin/FlutterSecureStorageDarwinPlugin.swift
@@ -157,7 +157,7 @@ public class FlutterSecureStorageDarwinPlugin: NSObject, FlutterPlugin, FlutterS
             service: options["accountName"] as? String,
             isSynchronizable: (options["synchronizable"] as? String).flatMap { Bool($0) },
             accessibilityLevel: options["accessibility"] as? String,
-            usesDataProtectionKeychain: (options["useDataProtectionKeyChain"] as? String).flatMap { Bool($0) } ?? true,
+            usesDataProtectionKeychain: (options["usesDataProtectionKeychain"] as? String).flatMap { Bool($0) } ?? true,
             shouldReturnData: true, // Default behavior for most operations.
             itemLabel: options["label"] as? String,
             itemDescription: options["description"] as? String,


### PR DESCRIPTION
This PR fixes mismatched option keys between the Dart API and the Darwin (iOS/macOS) Swift plugin so that MacOsOptions (and related options) are correctly passed through to the keychain implementation.

Fixed keys:
* useDataProtectionKeyChain → usesDataProtectionKeychain

Fixes: On macOS without the keychain-access-groups entitlement (e.g. when App Sandbox is disabled or the entitlement is missing), keychain operations no longer fail with Unexpected security result code, Code: -34018, Message: A required entitlement isn't present. Using MacOsOptions(usesDataProtectionKeychain: false) now correctly switches to the file-based keychain and avoids this error.

## Usage

1. Sandboxed macOS app (e.g. Mac App Store)
Use Keychain Sharing in entitlements so the app can access the keychain:

```xml
<key>com.apple.security.app-sandbox</key>
<true/>
<array>
  <string>$(AppIdentifierPrefix)com.example.app</string>
</array>
```

(Add to both DebugProfile.entitlements and Release.entitlements.)

<img width="1068" height="742" alt="image" src="https://github.com/user-attachments/assets/1f57d59e-fc17-46bd-8d6b-257743a1973d" />


2. Non–App Store / non-sandboxed macOS app

If you do not use App Sandbox or prefer not to rely on keychain-access-groups, use the traditional file-based keychain by turning off the data protection keychain in options:

```dart
FlutterSecureStorage(
  mOptions: MacOsOptions(
    accessibility: KeychainAccessibility.first_unlock_this_device,
    usesDataProtectionKeychain: false,
  ),
);
```

With usesDataProtectionKeychain: false, keychain access no longer depends on the keychain-access-groups entitlement. Do not use accessControlFlags or useSecureEnclave if you want to avoid Data Protection Keychain and its entitlement requirements.

<img width="1068" height="742" alt="image" src="https://github.com/user-attachments/assets/6b1c345d-dbd8-4305-82cb-94d99a69fee0" />
