### PR TITLE
fix(android): prevent duplicate biometric result callbacks

### DIFF
--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
@@ -1083,7 +1083,10 @@ public class FlutterSecureStorage {
             public void onAuthenticationFailed() {
                 super.onAuthenticationFailed();
                 Log.w(TAG, "Biometric authentication failed, user not recognized");
-                securePreferencesCallback.onError(new Exception("Biometric authentication failed, user not recognized"));
+                // Keep the prompt active so user can retry.
+                // Completing with error here causes Dart result to be delivered
+                // before the prompt is dismissed, then a later success callback
+                // can trigger a second result ("Reply already submitted").
             }
 
             @Override

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -11,6 +11,7 @@ import androidx.annotation.NonNull;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
@@ -83,8 +84,10 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
      */
     static class MethodResultWrapper implements Result {
 
+        private static final String TAG = "FlutterSecureStoragePlugin";
         private final Result methodResult;
         private final Handler handler = new Handler(Looper.getMainLooper());
+        private final AtomicBoolean isCompleted = new AtomicBoolean(false);
 
         MethodResultWrapper(Result methodResult) {
             this.methodResult = methodResult;
@@ -92,16 +95,28 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
 
         @Override
         public void success(final Object result) {
+            if (!isCompleted.compareAndSet(false, true)) {
+                Log.w(TAG, "Ignoring duplicate success callback");
+                return;
+            }
             handler.post(() -> methodResult.success(result));
         }
 
         @Override
         public void error(@NonNull final String errorCode, final String errorMessage, final Object errorDetails) {
+            if (!isCompleted.compareAndSet(false, true)) {
+                Log.w(TAG, "Ignoring duplicate error callback");
+                return;
+            }
             handler.post(() -> methodResult.error(errorCode, errorMessage, errorDetails));
         }
 
         @Override
         public void notImplemented() {
+            if (!isCompleted.compareAndSet(false, true)) {
+                Log.w(TAG, "Ignoring duplicate notImplemented callback");
+                return;
+            }
             handler.post(methodResult::notImplemented);
         }
     }


### PR DESCRIPTION
### Summary
- Keep the biometric prompt active on `onAuthenticationFailed()` (do not complete the operation there).
- Add a one-shot guard in `MethodResultWrapper` using `AtomicBoolean` so only the first callback is delivered.
- Ignore duplicate `success/error/notImplemented` callbacks to prevent duplicate Dart replies.

### Why
On Android, `onAuthenticationFailed()` is non-terminal and may be followed by `onAuthenticationSucceeded()` in the same prompt session.  
Returning an error too early can cause a second result later, leading to:

`java.lang.IllegalStateException: Reply already submitted`

### Scope
Android-only internal behavior fix. No public API changes.

### Validation
- Reproduced flow: fail biometric once, then retry in same prompt.
- Confirmed no duplicate result delivery.
- Ran `flutter analyze` (only existing unrelated lint warning).

Refs #1059 
