### PR TITLE
## fix(iOS): kSecAttrSynchronizable silently dropped when no access control flags are set

### DIFF
--- a/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin/Sources/flutter_secure_storage_darwin/FlutterSecureStorage.swift
+++ b/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin/Sources/flutter_secure_storage_darwin/FlutterSecureStorage.swift
@@ -131,7 +131,13 @@ class FlutterSecureStorage {
     }
     
     /// Creates an access control object based on the provided parameters.
+    /// NOTE: Only create AccessControl when explicit security flags (biometrics/passcode) are
+    /// provided. Without flags, baseQuery sets kSecAttrAccessible + kSecAttrSynchronizable as
+    /// plain attributes — which is required for extension targets (e.g. NotificationServiceExtension)
+    /// to access items via kSecAttrSynchronizable:true. Using kSecAttrAccessControl prevents
+    /// kSecAttrSynchronizable from being set, making the item invisible to the NSE.
     private func createAccessControl(params: KeychainQueryParameters) -> SecAccessControl? {
+        guard let flagString = params.accessControlFlags, !flagString.isEmpty else { return nil }
         guard let accessibilityLevel = params.accessibilityLevel else { return nil }
         let protection = parseAccessibleAttr(accessibilityLevel)
         let flags = parseAccessControlFlags(params.accessControlFlags)


### PR DESCRIPTION
### Problem

When writing a keychain item with `synchronizable: true` but **no** 
`accessControlFlags`, `createAccessControl()` returns a valid 
`SecAccessControl` object based solely on `accessibility`. 

Apple's Security framework **silently ignores** `kSecAttrSynchronizable` 
whenever `kSecAttrAccessControl` is present in the same query 
([documented here](https://developer.apple.com/documentation/security/ksecattrsynchronizable)).
The item is stored without the synchronizable attribute.

This is a **silent regression** introduced in `flutter_secure_storage_darwin 0.2.0` 
(v10 of the main package). The previous iOS-only implementation (`v9`) set 
`kSecAttrAccessible` and `kSecAttrSynchronizable` as plain attributes and 
was unaffected.

### Impact

Any target that reads keychain items with `kSecAttrSynchronizable: true` - 
most notably **iOS Notification Service Extensions**, **Share Extensions**, 
or any other app extension sharing a keychain access group - will fail to 
find items written by the main app, even with matching `groupId`, 
`accountName`, and `accessibility` settings.

### Root cause

`createAccessControl()` guards only on `accessibilityLevel` being non-nil:

```swift
// v0.2.0 — fires even with empty flags
guard let accessibilityLevel = params.accessibilityLevel else { return nil }