### PR TITLE
Fix compile on VS2022

### DIFF
--- a/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
+++ b/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
@@ -52,7 +52,7 @@ namespace
         const flutter::EncodableMap *args);
 
     // Derive the key for a value given a method argument map.
-    std::optional<std::string> FlutterSecureStorageWindowsPlugin::GetValueKey(const flutter::EncodableMap *args);
+    std::optional<std::string> GetValueKey(const flutter::EncodableMap *args);
 
     // Removes prefix of the given storage key.
     // 
@@ -776,7 +776,7 @@ namespace
     for (DWORD i = 0; i < cred_count; i++)
     {
       auto pcred = pcreds[i];
-      std::string target_name = CW2A(pcred->TargetName);
+      std::string target_name(CW2A(pcred->TargetName));
       auto val = std::string((char*)pcred->CredentialBlob);
       auto key = this->RemoveKeyPrefix(target_name);
       //If the key exists then data was already read from a file, which implies that the data read from the credential system is outdated


### PR DESCRIPTION
Hi，Maintainers.

I would like to fix this per #888, since I am building it on Windows 11 with VS2022. MS has said the STL behavior now have been th same as gcc/clang, so i guess it's better to keep track with latest behavior and ensure the library can be built with modern toolchains. If theres any concerns please let me know, thanks.