### PR TITLE
fix: potential key skipping in `readAll`

### DIFF
--- a/flutter_secure_storage_web/CHANGELOG.md
+++ b/flutter_secure_storage_web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT
+- Fix potential key skipping in `readAll` when storage is modified concurrently during async decryption by collecting keys synchronously before awaiting.
+
 ## 2.1.0
 - Updated code style
 - Add check for secure context, since operations are only allowed with secure context.

--- a/flutter_secure_storage_web/lib/flutter_secure_storage_web.dart
+++ b/flutter_secure_storage_web/lib/flutter_secure_storage_web.dart
@@ -104,18 +104,16 @@ class FlutterSecureStorageWeb extends FlutterSecureStoragePlatform {
     final storage = _getStorage(options);
     final map = <String, String>{};
     final prefix = '${options[_publicKey]!}.';
+
+    final keys = <String>[];
     for (var j = 0; j < storage.length; j++) {
       final key = storage.key(j) ?? '';
-      if (!key.startsWith(prefix)) {
-        continue;
-      }
+      if (key.startsWith(prefix)) keys.add(key);
+    }
 
+    for (final key in keys) {
       final value = await _decryptValue(storage.getItem(key), options);
-
-      if (value == null) {
-        continue;
-      }
-
+      if (value == null) continue;
       map[key.substring(prefix.length)] = value;
     }
 


### PR DESCRIPTION
supersedes #1061 and #1062

Fix potential key skipping in `readAll` when storage is modified concurrently during async decryption by collecting keys synchronously before awaiting.