### PR TITLE
fix: align android default to the flutter one

### DIFF
--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorageConfig.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorageConfig.java
@@ -19,7 +19,7 @@ public class FlutterSecureStorageConfig {
     private static final String DEFAULT_BIOMETRIC_PROMPT_TITLE = "Authenticate to access";
     private static final String DEFAULT_BIOMETRIC_PROMPT_SUBTITLE = "Use biometrics or device credentials";
     private static final String DEFAULT_STORAGE_CIPHER_ALGORITHM = "AES_GCM_NoPadding";
-    private static final String DEFAULT_KEY_CIPHER_ALGORITHM = "RSA_ECB_PKCS1Padding";
+    private static final String DEFAULT_KEY_CIPHER_ALGORITHM = "RSA_ECB_OAEPwithSHA_256andMGF1Padding";
 
     public static final String PREF_OPTION_NAME = "sharedPreferencesName";
     public static final String PREF_OPTION_PREFIX = "preferencesKeyPrefix";

--- a/flutter_secure_storage/android/src/test/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorageConfigTest.java
+++ b/flutter_secure_storage/android/src/test/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorageConfigTest.java
@@ -79,7 +79,7 @@ public class FlutterSecureStorageConfigTest {
 
     @Test
     public void defaults_keyCipherAlgorithm() {
-        assertEquals("RSA_ECB_PKCS1Padding", emptyConfig().getPrefOptionKeyCipherAlgorithm());
+        assertEquals("RSA_ECB_OAEPwithSHA_256andMGF1Padding", emptyConfig().getPrefOptionKeyCipherAlgorithm());
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Flutter default options use KeyCipherAlgorithm.RSA_ECB_OAEPwithSHA_256andMGF1Padding
While android was using DEFAULT_KEY_CIPHER_ALGORITHM = "RSA_ECB_PKCS1Padding"
This meant trying to access keys from native android with default options would cause a migration and broke it.

This simple change updates the Android side default to match the flutter one so people can use secure storage from both sides without specifying an option.