### PR TITLE
fix(flutter_secure_storage_windows): Support win32 6.x

### DIFF
--- a/flutter_secure_storage_windows/example/pubspec.yaml
+++ b/flutter_secure_storage_windows/example/pubspec.yaml
@@ -3,8 +3,8 @@ description: Demonstrates how to use the flutter_secure_storage_windows plugin.
 publish_to: 'none'
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
-  flutter: '>=3.22.0'
+  sdk: '>=3.10.0 <4.0.0'
+  flutter: '>=3.41.0'
 
 dependencies:
   flutter:

--- a/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_ffi.dart
+++ b/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_ffi.dart
@@ -297,25 +297,24 @@ class DpapiJsonFileMapStorage extends MapStorage {
         // Specify size of the struct explicitly.
         final plainTextBlob =
             alloc.allocate<CRYPT_INTEGER_BLOB>(sizeOf<CRYPT_INTEGER_BLOB>());
-        if (CryptUnprotectData(
-              encryptedTextBlob,
-              nullptr,
-              nullptr,
-              nullptr,
-              nullptr,
-              0,
-              plainTextBlob,
-            ) ==
-            0) {
+        final decryptResult = CryptUnprotectData(
+          encryptedTextBlob,
+          null,
+          null,
+          null,
+          0,
+          plainTextBlob,
+        );
+        if (!decryptResult.value) {
           throw WindowsException(
-            GetLastError(),
+            decryptResult.error.toHRESULT(),
             message: 'Failure on CryptUnprotectData()',
           );
         }
 
         if (plainTextBlob.ref.pbData.address == NULL) {
           throw WindowsException(
-            ERROR_OUTOFMEMORY,
+            ERROR_OUTOFMEMORY.toHRESULT(),
             message: 'Failure on CryptUnprotectData()',
           );
         }
@@ -326,10 +325,11 @@ class DpapiJsonFileMapStorage extends MapStorage {
           );
         } finally {
           if (plainTextBlob.ref.pbData.address != NULL) {
-            if (LocalFree(plainTextBlob.ref.pbData).address != NULL) {
+            final freeResult = LocalFree(HLOCAL(plainTextBlob.ref.pbData));
+            if (freeResult.error.isError) {
               debugPrint(
                 'load: Failed to LocalFree with: '
-                '0x${GetLastError().toHexString(32)}',
+                '${freeResult.error.toHRESULT().toHexString(32)}',
               );
             }
           }
@@ -401,25 +401,24 @@ class DpapiJsonFileMapStorage extends MapStorage {
       // Specify size of the struct explicitly.
       final encryptedTextBlob =
           alloc.allocate<CRYPT_INTEGER_BLOB>(sizeOf<CRYPT_INTEGER_BLOB>());
-      if (CryptProtectData(
-            plainTextBlob,
-            nullptr,
-            nullptr,
-            nullptr,
-            nullptr,
-            0,
-            encryptedTextBlob,
-          ) ==
-          0) {
+      final encryptResult = CryptProtectData(
+        plainTextBlob,
+        null,
+        null,
+        null,
+        0,
+        encryptedTextBlob,
+      );
+      if (!encryptResult.value) {
         throw WindowsException(
-          GetLastError(),
+          encryptResult.error.toHRESULT(),
           message: 'Failure on CryptProtectData()',
         );
       }
 
       if (encryptedTextBlob.ref.pbData.address == NULL) {
         throw WindowsException(
-          ERROR_OUTOFMEMORY,
+          ERROR_OUTOFMEMORY.toHRESULT(),
           message: 'Failure on CryptProtectData()',
         );
       }
@@ -446,10 +445,11 @@ class DpapiJsonFileMapStorage extends MapStorage {
         }
       } finally {
         if (encryptedTextBlob.ref.pbData.address != NULL) {
-          if (LocalFree(encryptedTextBlob.ref.pbData).address != NULL) {
+          final freeResult = LocalFree(HLOCAL(encryptedTextBlob.ref.pbData));
+          if (freeResult.error.isError) {
             debugPrint(
               'save: Failed to LocalFree with: '
-              '0x${GetLastError().toHexString(32)}',
+              '${freeResult.error.toHRESULT().toHexString(32)}',
             );
           }
         }

--- a/flutter_secure_storage_windows/pubspec.yaml
+++ b/flutter_secure_storage_windows/pubspec.yaml
@@ -4,8 +4,8 @@ repository: https://github.com/mogol/flutter_secure_storage
 version: 4.1.0
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
-  flutter: '>=3.19.0'
+  sdk: '>=3.10.0 <4.0.0'
+  flutter: '>=3.41.0'
 
 dependencies:
   ffi: ^2.0.0
@@ -14,7 +14,7 @@ dependencies:
   flutter_secure_storage_platform_interface: ^2.0.0
   path: ^1.8.0
   path_provider: ^2.0.0
-  win32: ^5.5.4
+  win32: ^6.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description
Update the Windows implementation for the newer `win32` API and keep the storage layer building on current Dart packages. This unblocks the app from the older `win32` line that holds back dependency upgrades.

## Related Issues
None.

## Checklist
- [x] I read the repo guidance and followed the contribution flow.
- [x] I used a short Conventional Commits title.
- [x] I did not change unrelated package metadata.
- [x] I ran `flutter pub get`, the Windows example build, and the app validation with the local override.
- [x] The change does not add a breaking API.

## Breaking Change
No, this is not a breaking change.
