### PR TITLE
Raise Darwin minimums for CryptoKit APIs

### DIFF
--- a/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin.podspec
+++ b/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin.podspec
@@ -16,7 +16,7 @@ A Flutter plugin to store data in secure storage.
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
   s.ios.deployment_target = '13.0'
-  s.osx.deployment_target = '10.14'
+  s.osx.deployment_target = '10.15'
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'

--- a/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin.podspec
+++ b/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin.podspec
@@ -15,7 +15,7 @@ A Flutter plugin to store data in secure storage.
   s.source_files = 'flutter_secure_storage_darwin/Sources/flutter_secure_storage_darwin/**/*.swift'
   s.ios.dependency 'Flutter'
   s.osx.dependency 'FlutterMacOS'
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '13.0'
   s.osx.deployment_target = '10.14'
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin/Package.swift
+++ b/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "flutter_secure_storage_darwin",
     platforms: [
-        .iOS("12.0"),
+        .iOS("13.0"),
         .macOS("10.14")
     ],
     products: [

--- a/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin/Package.swift
+++ b/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "flutter_secure_storage_darwin",
     platforms: [
         .iOS("13.0"),
-        .macOS("10.14")
+        .macOS("10.15")
     ],
     products: [
         .library(name: "flutter-secure-storage-darwin", targets: ["flutter_secure_storage_darwin"])


### PR DESCRIPTION
## Draft status

This PR aligns the Darwin package metadata with the CryptoKit APIs used by `flutter_secure_storage_darwin`. The implementation imports CryptoKit and uses APIs such as `SymmetricKey` / `AES`, so the declared minimums need to cover CryptoKit availability.

This is not a metadata-only warning suppression: it keeps the CocoaPods and Swift Package Manager paths consistent by updating both the podspec and `Package.swift`.

## Scope

- iOS minimum: 12.0 -> 13.0
- macOS minimum: 10.14 -> 10.15
- Updates both `flutter_secure_storage_darwin.podspec` and `Package.swift`
- No Dart APIs or runtime code are changed.

## Verification

- Consuming app `flutter build ios --simulator --debug` passed after pinning this fork.
- `git diff --check`
