### PR TITLE
docs(readme): improve Linux platform setup / build (libsecret)

### DIFF
--- a/flutter_secure_storage/README.md
+++ b/flutter_secure_storage/README.md
@@ -341,7 +341,57 @@ You need the C++ ATL libraries installed along with the rest of Visual Studio Bu
 
 ### Linux
 
-You need `libsecret-1-dev` on your machine to build the project, and `libsecret-1-0` to run the application (add it as a dependency after packaging your app). If you using snapcraft to build the project use the following
+You need to install [Libsecret](https://github.com/GNOME/libsecret) pacakges:
+
+1. **development package**: on your machine to build the project
+2. **runtime pacakge**: to run the application (add it as a dependency after packaging your app).
+
+<details>
+	<summary>Apt / Dnf / Pacman</summary>
+
+For Ubuntu / Debian-based distros (e.g., Linux Mint, PopOS):
+
+```shell
+sudo apt install libsecret-1-0 libsecret-1-dev
+```
+
+For Fedora / RHEL / CentOS distros:
+
+```shell
+sudo dnf install libsecret libsecret-devel
+```
+
+For Arch based distros (a single package containing both development and runtime modules):
+
+```shell
+sudo pacman -S libsecret
+```
+
+	
+</details>
+
+<details>
+	<summary>Flatpak / Flathub</summary>
+
+[Libsecret supports](https://github.com/GNOME/libsecret#libsecret) both `org.freedesktop.Secret` and `org.freedesktop.portal.Secret` 
+and is compatible with Flatpak or sandboxed apps.
+
+Freedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10 and 5.15-25.08) provides libsecret; therefore, it no longer needs to be compiled ([flathub/shared-modules/#424](https://github.com/flathub/shared-modules/issues/424)) in your app manifest:
+
+```yaml
+runtime: org.freedesktop.Platform
+runtime-version: '25.08' # Should be at least 25.08 (or newer)
+```
+
+> However, if you are still using an older runtime, you may use [Flathub Shared Modules](https://docs.flathub.org/docs/for-app-authors/shared-modules)
+and add `shared-modules/libsecret/libsecret.json` (**no longer recommend** and will be removed).
+	
+</details>
+
+<details>
+	<summary>Snapcraft</summary>
+
+If you using snapcraft to build the project, use the following:
 
 ```yaml
 parts:
@@ -355,7 +405,13 @@ parts:
       - libsecret-1-0
 ```
 
-Apart from `libsecret` you also need a keyring service, for that you need either [`gnome-keyring`](https://wiki.gnome.org/Projects/GnomeKeyring) (for Gnome users) or [`kwalletmanager`](https://wiki.archlinux.org/title/KDE_Wallet) (for KDE users) or other light provider like [`secret-service`](https://github.com/yousefvand/secret-service).
+</details>
+
+Apart from `libsecret`, you also need a keyring service. This is typically already installed by the desktop environment:
+
+- [`gnome-keyring`](https://wiki.gnome.org/Projects/GnomeKeyring) (for Gnome users)
+- [`kwalletmanager`](https://wiki.archlinux.org/title/KDE_Wallet) (for KDE users)
+- Or a light provider such as [`secret-service`](https://github.com/yousefvand/secret-service)
 
 ## Integration Tests
 


### PR DESCRIPTION
- Adds Flathub / Flatpak instructions. libsecret is already included in newer runtimes and works out of the box ([Related issue](https://github.com/flathub/shared-modules/issues/424))
- Adds instructions for dnf and pacman package managers
- Separates snapcraft / Ubuntu setup from Flathub and other distros

This makes it easier for developers and users to support and test this plugin on Linux desktops:

- Whether they are an Arch Linux user trying to build the app from source
- Or they want to publish to Flathub
  - Some plugins do not use the supported portals by default (e.g., https://github.com/fluttercommunity/plus_plugins/issues/1241), which results in Flathub rejection. This README change indicates that this plugin complies with Flathub policy.