### PR TITLE
feat: add AndroidBiometricType option to restrict authentication to strong biometrics only

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ final storage = FlutterSecureStorage(
 | `AndroidBiometricType.biometricOrDeviceCredential` | Class 3 biometrics **or** PIN / pattern / password (default) |
 | `AndroidBiometricType.strongBiometricOnly`  | Class 3 (strong) biometrics only — credentials rejected |
 
-> **Note:** On Android 10 (API level 29) and lower, `setAllowedAuthenticators` is not available and the system may still allow device credentials regardless of this setting.
+> **Note:** On Android 10 (API level 29) and lower, `setAllowedAuthenticators` is unavailable. Device credentials (PIN/pattern/password) are not accepted on these versions — only Class 3 (strong) biometrics work, regardless of the `biometricType` setting.
 
 ##### Requirements
 

--- a/README.md
+++ b/README.md
@@ -142,11 +142,12 @@ Add the following to your `android/app/src/main/AndroidManifest.xml`:
 
 Version 10 introduces new cipher options and biometric support. Choose the configuration that fits your security requirements:
 
-| Constructor                                          | Key Cipher                            | Storage Cipher    | Biometric Support | Description                                                                                                                                          |
-|------------------------------------------------------|---------------------------------------|-------------------|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `AndroidOptions()`                                   | RSA/ECB/OAEPWithSHA-256AndMGF1Padding | AES/GCM/NoPadding | No                | **Default.** Standard secure storage with RSA OAEP key wrapping. Strong authenticated encryption without biometrics. Recommended for most use cases. |
-| `AndroidOptions.biometric(enforceBiometrics: false)` | AES/GCM/NoPadding                     | AES/GCM/NoPadding | Optional          | KeyStore-based with optional biometric authentication. Gracefully degrades if biometrics unavailable.                                                |
-| `AndroidOptions.biometric(enforceBiometrics: true)`  | AES/GCM/NoPadding                     | AES/GCM/NoPadding | Required          | KeyStore-based requiring biometric/PIN authentication. Throws error if device security not available. Requires API 28+ for biometric enforcement.    |
+| Constructor                                                                                              | Key Cipher                            | Storage Cipher    | Biometric Support | Description                                                                                                                                          |
+|----------------------------------------------------------------------------------------------------------|---------------------------------------|-------------------|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `AndroidOptions()`                                                                                       | RSA/ECB/OAEPWithSHA-256AndMGF1Padding | AES/GCM/NoPadding | No                | **Default.** Standard secure storage with RSA OAEP key wrapping. Strong authenticated encryption without biometrics. Recommended for most use cases. |
+| `AndroidOptions.biometric(enforceBiometrics: false)`                                                     | AES/GCM/NoPadding                     | AES/GCM/NoPadding | Optional          | KeyStore-based with optional biometric authentication. Gracefully degrades if biometrics unavailable.                                                |
+| `AndroidOptions.biometric(enforceBiometrics: true)`                                                      | AES/GCM/NoPadding                     | AES/GCM/NoPadding | Required          | KeyStore-based requiring biometric/PIN authentication. Throws error if device security not available. Requires API 28+ for biometric enforcement.    |
+| `AndroidOptions.biometric(enforceBiometrics: true, biometricType: AndroidBiometricType.strongBiometricOnly)` | AES/GCM/NoPadding                 | AES/GCM/NoPadding | Required (strong) | Same as above but restricts authentication to Class 3 (strong) biometrics only. Device credentials (PIN/pattern/password) are rejected.              |
 
 #### Custom Cipher Combinations (Advanced)
 
@@ -209,14 +210,33 @@ final storage = FlutterSecureStorage(
     biometricPromptTitle: 'Biometric authentication required',
   ),
 );
+
+// Strong biometric only — device credentials (PIN/pattern/password) rejected
+final storage = FlutterSecureStorage(
+  aOptions: AndroidOptions.biometric(
+    enforceBiometrics: true,
+    biometricType: AndroidBiometricType.strongBiometricOnly,
+    biometricPromptTitle: 'Fingerprint required',
+  ),
+);
 ```
 
 **Note:** When `enforceBiometrics: true`, the app will throw an exception if the device has no PIN, pattern, password, or biometric enrolled.
+
+**`biometricType`** controls which authentication methods satisfy the biometric prompt (only applies when using `AES_GCM_NoPadding` key cipher):
+
+| Value                                       | Accepted methods                                        |
+|---------------------------------------------|---------------------------------------------------------|
+| `AndroidBiometricType.biometricOrDeviceCredential` | Class 3 biometrics **or** PIN / pattern / password (default) |
+| `AndroidBiometricType.strongBiometricOnly`  | Class 3 (strong) biometrics only — credentials rejected |
+
+> **Note:** On Android 10 (API level 29) and lower, `setAllowedAuthenticators` is not available and the system may still allow device credentials regardless of this setting.
 
 ##### Requirements
 
 - **API Level**: Android 6.0 (API 23) minimum for basic encryption
 - **API Level**: Android 9.0 (API 28) minimum for enforced biometric authentication
+- **API Level**: Android 11.0 (API 30) minimum for `AndroidBiometricType.strongBiometricOnly` to be fully enforced
 - **Device Security**: Device must have a PIN, pattern, password, or biometric enrolled (when using `enforceBiometrics: true`)
 - **Permissions**: `USE_BIOMETRIC` permission in AndroidManifest.xml
 

--- a/flutter_secure_storage/CHANGELOG.md
+++ b/flutter_secure_storage/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 10.3.0
+
+### Android
+- Added `AndroidBiometricType` enum and `biometricType` option to `AndroidOptions` to control which authentication methods are accepted during biometric prompts (requires `KeyCipherAlgorithm.AES_GCM_NoPadding`).
+  - `AndroidBiometricType.biometricOrDeviceCredential` (default) — accepts Class 3 biometrics or device credentials (PIN/pattern/password), preserving previous behaviour.
+  - `AndroidBiometricType.strongBiometricOnly` — restricts authentication to Class 3 (strong) biometrics only; device credentials are explicitly rejected.
+- Fully enforced on Android 11+ (API 30+) via `setAllowedAuthenticators` on `BiometricPrompt` and `setUserAuthenticationParameters` on the KeyStore key. On earlier API levels the system may still permit device credentials.
+
 ## 10.2.0
 
 ### Android

--- a/flutter_secure_storage/README.md
+++ b/flutter_secure_storage/README.md
@@ -142,11 +142,12 @@ Add the following to your `android/app/src/main/AndroidManifest.xml`:
 
 Version 10 introduces new cipher options and biometric support. Choose the configuration that fits your security requirements:
 
-| Constructor                                          | Key Cipher                            | Storage Cipher    | Biometric Support | Description                                                                                                                                          |
-|------------------------------------------------------|---------------------------------------|-------------------|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `AndroidOptions()`                                   | RSA/ECB/OAEPWithSHA-256AndMGF1Padding | AES/GCM/NoPadding | No                | **Default.** Standard secure storage with RSA OAEP key wrapping. Strong authenticated encryption without biometrics. Recommended for most use cases. |
-| `AndroidOptions.biometric(enforceBiometrics: false)` | AES/GCM/NoPadding                     | AES/GCM/NoPadding | Optional          | KeyStore-based with optional biometric authentication. Gracefully degrades if biometrics unavailable.                                                |
-| `AndroidOptions.biometric(enforceBiometrics: true)`  | AES/GCM/NoPadding                     | AES/GCM/NoPadding | Required          | KeyStore-based requiring biometric/PIN authentication. Throws error if device security not available. Requires API 28+ for biometric enforcement.    |
+| Constructor                                                                                              | Key Cipher                            | Storage Cipher    | Biometric Support | Description                                                                                                                                          |
+|----------------------------------------------------------------------------------------------------------|---------------------------------------|-------------------|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `AndroidOptions()`                                                                                       | RSA/ECB/OAEPWithSHA-256AndMGF1Padding | AES/GCM/NoPadding | No                | **Default.** Standard secure storage with RSA OAEP key wrapping. Strong authenticated encryption without biometrics. Recommended for most use cases. |
+| `AndroidOptions.biometric(enforceBiometrics: false)`                                                     | AES/GCM/NoPadding                     | AES/GCM/NoPadding | Optional          | KeyStore-based with optional biometric authentication. Gracefully degrades if biometrics unavailable.                                                |
+| `AndroidOptions.biometric(enforceBiometrics: true)`                                                      | AES/GCM/NoPadding                     | AES/GCM/NoPadding | Required          | KeyStore-based requiring biometric/PIN authentication. Throws error if device security not available. Requires API 28+ for biometric enforcement.    |
+| `AndroidOptions.biometric(enforceBiometrics: true, biometricType: AndroidBiometricType.strongBiometricOnly)` | AES/GCM/NoPadding                 | AES/GCM/NoPadding | Required (strong) | Same as above but restricts authentication to Class 3 (strong) biometrics only. Device credentials (PIN/pattern/password) are rejected.              |
 
 #### Custom Cipher Combinations (Advanced)
 
@@ -266,14 +267,33 @@ final storage = FlutterSecureStorage(
     biometricPromptTitle: 'Biometric authentication required',
   ),
 );
+
+// Strong biometric only — device credentials (PIN/pattern/password) rejected
+final storage = FlutterSecureStorage(
+  aOptions: AndroidOptions.biometric(
+    enforceBiometrics: true,
+    biometricType: AndroidBiometricType.strongBiometricOnly,
+    biometricPromptTitle: 'Fingerprint required',
+  ),
+);
 ```
 
 **Note:** When `enforceBiometrics: true`, the app will throw an exception if the device has no PIN, pattern, password, or biometric enrolled.
+
+**`biometricType`** controls which authentication methods satisfy the biometric prompt (only applies when using `AES_GCM_NoPadding` key cipher):
+
+| Value                                       | Accepted methods                                        |
+|---------------------------------------------|---------------------------------------------------------|
+| `AndroidBiometricType.biometricOrDeviceCredential` | Class 3 biometrics **or** PIN / pattern / password (default) |
+| `AndroidBiometricType.strongBiometricOnly`  | Class 3 (strong) biometrics only — credentials rejected |
+
+> **Note:** On Android 10 (API level 29) and lower, `setAllowedAuthenticators` is not available and the system may still allow device credentials regardless of this setting.
 
 ##### Requirements
 
 - **API Level**: Android 6.0 (API 23) minimum for basic encryption
 - **API Level**: Android 9.0 (API 28) minimum for enforced biometric authentication
+- **API Level**: Android 11.0 (API 30) minimum for `AndroidBiometricType.strongBiometricOnly` to be fully enforced
 - **Device Security**: Device must have a PIN, pattern, password, or biometric enrolled (when using `enforceBiometrics: true`)
 - **Permissions**: `USE_BIOMETRIC` permission in AndroidManifest.xml
 

--- a/flutter_secure_storage/README.md
+++ b/flutter_secure_storage/README.md
@@ -287,7 +287,7 @@ final storage = FlutterSecureStorage(
 | `AndroidBiometricType.biometricOrDeviceCredential` | Class 3 biometrics **or** PIN / pattern / password (default) |
 | `AndroidBiometricType.strongBiometricOnly`  | Class 3 (strong) biometrics only — credentials rejected |
 
-> **Note:** On Android 10 (API level 29) and lower, `setAllowedAuthenticators` is not available and the system may still allow device credentials regardless of this setting.
+> **Note:** On Android 10 (API level 29) and lower, `setAllowedAuthenticators` is unavailable. Device credentials (PIN/pattern/password) are not accepted on these versions — only Class 3 (strong) biometrics work, regardless of the `biometricType` setting.
 
 ##### Requirements
 

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
@@ -1141,6 +1141,9 @@ public class FlutterSecureStorage {
 
         BiometricPrompt.CryptoObject crypto = new BiometricPrompt.CryptoObject(cipher);
 
+        CancellationSignal cancellationSignal = new CancellationSignal();
+        Executor executor = Executors.newSingleThreadExecutor();
+
         BiometricPrompt.Builder promptInfoBuilder = new BiometricPrompt.Builder(context)
                 .setTitle(config.getBiometricPromptTitle())
                 .setSubtitle(config.getPrefOptionBiometricPromptSubtitle());
@@ -1150,13 +1153,19 @@ public class FlutterSecureStorage {
                     ? BiometricManager.Authenticators.BIOMETRIC_STRONG
                     : BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.DEVICE_CREDENTIAL;
             promptInfoBuilder.setAllowedAuthenticators(authenticators);
+            // DEVICE_CREDENTIAL as a fallback conflicts with a negative button; only add one
+            // when using strong-biometric-only (no credential fallback).
+            if (config.isStrongBiometricOnly()) {
+                promptInfoBuilder.setNegativeButton(config.getBiometricPromptNegativeButton(), executor, (dialog, which) -> cancellationSignal.cancel());
+            }
+        } else {
+            // Android 10 (API level 29) and lower: setAllowedAuthenticators is unavailable.
+            // Device credentials are not enabled (setDeviceCredentialAllowed defaults to false),
+            // so a negative button is required.
+            promptInfoBuilder.setNegativeButton(config.getBiometricPromptNegativeButton(), executor, (dialog, which) -> cancellationSignal.cancel());
         }
 
-        BiometricPrompt promptInfo = promptInfoBuilder
-                .build();
-
-        CancellationSignal cancellationSignal = new CancellationSignal();
-        Executor executor = Executors.newSingleThreadExecutor();
+        BiometricPrompt promptInfo = promptInfoBuilder.build();
 
         BiometricPrompt.AuthenticationCallback callback = new BiometricPrompt.AuthenticationCallback() {
             @Override

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
@@ -1022,10 +1022,10 @@ public class FlutterSecureStorage {
             BiometricManager biometricManager = context.getSystemService(BiometricManager.class);
             if (biometricManager == null) return false;
 
-            int result = biometricManager.canAuthenticate(
-                    BiometricManager.Authenticators.BIOMETRIC_STRONG |
-                            BiometricManager.Authenticators.DEVICE_CREDENTIAL
-            );
+            int authenticators = config.isStrongBiometricOnly()
+                    ? BiometricManager.Authenticators.BIOMETRIC_STRONG
+                    : BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.DEVICE_CREDENTIAL;
+            int result = biometricManager.canAuthenticate(authenticators);
 
             return result == BiometricManager.BIOMETRIC_SUCCESS && isDeviceSecure();
         } else {
@@ -1083,10 +1083,10 @@ public class FlutterSecureStorage {
                 return;
             }
 
-            int result = biometricManager.canAuthenticate(
-                    BiometricManager.Authenticators.BIOMETRIC_STRONG |
-                            BiometricManager.Authenticators.DEVICE_CREDENTIAL
-            );
+            int authenticators = config.isStrongBiometricOnly()
+                    ? BiometricManager.Authenticators.BIOMETRIC_STRONG
+                    : BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.DEVICE_CREDENTIAL;
+            int result = biometricManager.canAuthenticate(authenticators);
 
             // Handle specific BiometricManager status codes
             switch (result) {
@@ -1146,8 +1146,10 @@ public class FlutterSecureStorage {
                 .setSubtitle(config.getPrefOptionBiometricPromptSubtitle());
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            promptInfoBuilder
-                    .setAllowedAuthenticators(BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.DEVICE_CREDENTIAL);
+            int authenticators = config.isStrongBiometricOnly()
+                    ? BiometricManager.Authenticators.BIOMETRIC_STRONG
+                    : BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.DEVICE_CREDENTIAL;
+            promptInfoBuilder.setAllowedAuthenticators(authenticators);
         }
 
         BiometricPrompt promptInfo = promptInfoBuilder

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorageConfig.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorageConfig.java
@@ -9,6 +9,9 @@ import java.util.Map;
 
 public class FlutterSecureStorageConfig {
 
+    private static final String BIOMETRIC_TYPE_STRONG = "strongBiometricOnly";
+    private static final String BIOMETRIC_TYPE_DEVICE_CREDENTIAL = "biometricOrDeviceCredential";
+
     private static final String DEFAULT_PREF_NAME = "FlutterSecureStorage";
     private static final String DEFAULT_KEY_PREFIX = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBhIHNlY3VyZSBzdG9yYWdlCg";
     private static final Boolean DEFAULT_DELETE_ON_FAILURE = false;
@@ -16,6 +19,7 @@ public class FlutterSecureStorageConfig {
     private static final Boolean DEFAULT_MIGRATE_WITH_BACKUP = false;
     private static final Boolean DEFAULT_ENCRYPTED_SHARED_PREFERENCES = false;
     private static final Boolean DEFAULT_ENFORCE_BIOMETRICS = false;
+    private static final String DEFAULT_BIOMETRIC_TYPE = BIOMETRIC_TYPE_DEVICE_CREDENTIAL;
     private static final String DEFAULT_BIOMETRIC_PROMPT_TITLE = "Authenticate to access";
     private static final String DEFAULT_BIOMETRIC_PROMPT_SUBTITLE = "Use biometrics or device credentials";
     private static final String DEFAULT_STORAGE_CIPHER_ALGORITHM = "AES_GCM_NoPadding";
@@ -28,6 +32,7 @@ public class FlutterSecureStorageConfig {
     public static final String PREF_OPTION_MIGRATE_WITH_BACKUP = "migrateWithBackup";
     public static final String PREF_OPTION_ENCRYPTED_SHARED_PREFERENCES = "encryptedSharedPreferences";
     public static final String PREF_OPTION_ENFORCE_BIOMETRICS = "enforceBiometrics";
+    public static final String PREF_OPTION_BIOMETRIC_TYPE = "biometricType";
     public static final String PREF_OPTION_BIOMETRIC_PROMPT_TITLE = "biometricPromptTitle";
     public static final String PREF_OPTION_BIOMETRIC_PROMPT_SUBTITLE = "biometricPromptSubtitle";
     // Legacy keys kept for backwards compatibility.
@@ -48,6 +53,7 @@ public class FlutterSecureStorageConfig {
     private final boolean migrateWithBackup;
     private final boolean useEncryptedSharedPreferences;
     private final boolean enforceBiometrics;
+    private final boolean strongBiometricOnly;
     private final String biometricPromptTitle;
     private final String biometricPromptSubtitle;
     private final String keyCipherAlgorithm;
@@ -61,6 +67,12 @@ public class FlutterSecureStorageConfig {
         this.migrateWithBackup = getBooleanOption(options, PREF_OPTION_MIGRATE_WITH_BACKUP, DEFAULT_MIGRATE_WITH_BACKUP);
         this.useEncryptedSharedPreferences = getBooleanOption(options, PREF_OPTION_ENCRYPTED_SHARED_PREFERENCES, DEFAULT_ENCRYPTED_SHARED_PREFERENCES);
         this.enforceBiometrics = getBooleanOption(options, PREF_OPTION_ENFORCE_BIOMETRICS, DEFAULT_ENFORCE_BIOMETRICS);
+        String biometricTypeValue = getStringOption(options, PREF_OPTION_BIOMETRIC_TYPE, DEFAULT_BIOMETRIC_TYPE);
+        if (!BIOMETRIC_TYPE_STRONG.equals(biometricTypeValue) && !BIOMETRIC_TYPE_DEVICE_CREDENTIAL.equals(biometricTypeValue)) {
+            throw new IllegalArgumentException("Unknown biometricType: '" + biometricTypeValue + "'. "
+                    + "Expected one of: " + BIOMETRIC_TYPE_STRONG + ", " + BIOMETRIC_TYPE_DEVICE_CREDENTIAL);
+        }
+        this.strongBiometricOnly = BIOMETRIC_TYPE_STRONG.equals(biometricTypeValue);
         this.biometricPromptTitle = getStringOption(
                 options,
                 PREF_OPTION_BIOMETRIC_PROMPT_TITLE,
@@ -136,6 +148,7 @@ public class FlutterSecureStorageConfig {
 
     public boolean isUseEncryptedSharedPreferences() { return useEncryptedSharedPreferences; }
     public boolean getEnforceBiometrics() { return enforceBiometrics; }
+    public boolean isStrongBiometricOnly() { return strongBiometricOnly; }
 
     public String getBiometricPromptTitle() { return biometricPromptTitle; }
     public String getPrefOptionBiometricPromptSubtitle() { return biometricPromptSubtitle; }

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorageConfig.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorageConfig.java
@@ -22,6 +22,7 @@ public class FlutterSecureStorageConfig {
     private static final String DEFAULT_BIOMETRIC_TYPE = BIOMETRIC_TYPE_DEVICE_CREDENTIAL;
     private static final String DEFAULT_BIOMETRIC_PROMPT_TITLE = "Authenticate to access";
     private static final String DEFAULT_BIOMETRIC_PROMPT_SUBTITLE = "Use biometrics or device credentials";
+    private static final String DEFAULT_BIOMETRIC_PROMPT_NEGATIVE_BUTTON = "Cancel";
     private static final String DEFAULT_STORAGE_CIPHER_ALGORITHM = "AES_GCM_NoPadding";
     private static final String DEFAULT_KEY_CIPHER_ALGORITHM = "RSA_ECB_OAEPwithSHA_256andMGF1Padding";
 
@@ -35,6 +36,7 @@ public class FlutterSecureStorageConfig {
     public static final String PREF_OPTION_BIOMETRIC_TYPE = "biometricType";
     public static final String PREF_OPTION_BIOMETRIC_PROMPT_TITLE = "biometricPromptTitle";
     public static final String PREF_OPTION_BIOMETRIC_PROMPT_SUBTITLE = "biometricPromptSubtitle";
+    public static final String PREF_OPTION_BIOMETRIC_PROMPT_NEGATIVE_BUTTON = "biometricPromptNegativeButton";
     // Legacy keys kept for backwards compatibility.
     public static final String LEGACY_PREF_OPTION_BIOMETRIC_PROMPT_TITLE = "prefOptionBiometricPromptTitle";
     public static final String LEGACY_PREF_OPTION_BIOMETRIC_PROMPT_SUBTITLE = "prefOptionBiometricPromptSubtitle";
@@ -56,6 +58,7 @@ public class FlutterSecureStorageConfig {
     private final boolean strongBiometricOnly;
     private final String biometricPromptTitle;
     private final String biometricPromptSubtitle;
+    private final String biometricPromptNegativeButton;
     private final String keyCipherAlgorithm;
     private final String storageCipherAlgorithm;
 
@@ -85,6 +88,7 @@ public class FlutterSecureStorageConfig {
                 LEGACY_PREF_OPTION_BIOMETRIC_PROMPT_SUBTITLE,
                 DEFAULT_BIOMETRIC_PROMPT_SUBTITLE
         );
+        this.biometricPromptNegativeButton = getStringOption(options, PREF_OPTION_BIOMETRIC_PROMPT_NEGATIVE_BUTTON, DEFAULT_BIOMETRIC_PROMPT_NEGATIVE_BUTTON);
         this.storageCipherAlgorithm = getStringOption(options, PREF_OPTION_STORAGE_CIPHER_ALGORITHM, DEFAULT_STORAGE_CIPHER_ALGORITHM);
         this.keyCipherAlgorithm = getStringOption(options, PREF_OPTION_KEY_CIPHER_ALGORITHM, DEFAULT_KEY_CIPHER_ALGORITHM);
 
@@ -152,6 +156,7 @@ public class FlutterSecureStorageConfig {
 
     public String getBiometricPromptTitle() { return biometricPromptTitle; }
     public String getPrefOptionBiometricPromptSubtitle() { return biometricPromptSubtitle; }
+    public String getBiometricPromptNegativeButton() { return biometricPromptNegativeButton; }
     public String getPrefOptionStorageCipherAlgorithm() { return storageCipherAlgorithm; }
     public String getPrefOptionKeyCipherAlgorithm() { return keyCipherAlgorithm; }
 

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationAES23.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationAES23.java
@@ -160,8 +160,10 @@ class KeyCipherImplementationAES23 implements KeyCipher {
             builder.setUserAuthenticationRequired(true);
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                builder.setUserAuthenticationParameters(0,
-                        AUTH_DEVICE_CREDENTIAL | AUTH_BIOMETRIC_STRONG);
+                int authTypes = config.isStrongBiometricOnly()
+                        ? AUTH_BIOMETRIC_STRONG
+                        : AUTH_DEVICE_CREDENTIAL | AUTH_BIOMETRIC_STRONG;
+                builder.setUserAuthenticationParameters(0, authTypes);
             } else {
                 configureLegacyAuth(builder);
             }
@@ -205,8 +207,10 @@ class KeyCipherImplementationAES23 implements KeyCipher {
                     builder.setUserAuthenticationRequired(true);
 
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                        builder.setUserAuthenticationParameters(0,
-                                AUTH_DEVICE_CREDENTIAL | AUTH_BIOMETRIC_STRONG);
+                        int authTypes = config.isStrongBiometricOnly()
+                                ? AUTH_BIOMETRIC_STRONG
+                                : AUTH_DEVICE_CREDENTIAL | AUTH_BIOMETRIC_STRONG;
+                        builder.setUserAuthenticationParameters(0, authTypes);
                     } else {
                         configureLegacyAuth(builder);
                     }

--- a/flutter_secure_storage/android/src/test/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorageConfigTest.java
+++ b/flutter_secure_storage/android/src/test/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorageConfigTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class FlutterSecureStorageConfigTest {
 
@@ -57,6 +58,11 @@ public class FlutterSecureStorageConfigTest {
     @Test
     public void defaults_enforceBiometrics_isFalse() {
         assertFalse(emptyConfig().getEnforceBiometrics());
+    }
+
+    @Test
+    public void defaults_isStrongBiometricOnly_isFalse() {
+        assertFalse(emptyConfig().isStrongBiometricOnly());
     }
 
     @Test
@@ -120,6 +126,30 @@ public class FlutterSecureStorageConfigTest {
     public void custom_enforceBiometrics_true() {
         FlutterSecureStorageConfig config = configFrom(FlutterSecureStorageConfig.PREF_OPTION_ENFORCE_BIOMETRICS, "true");
         assertTrue(config.getEnforceBiometrics());
+    }
+
+    @Test
+    public void custom_biometricType_strongBiometricOnly() {
+        FlutterSecureStorageConfig config = configFrom(FlutterSecureStorageConfig.PREF_OPTION_BIOMETRIC_TYPE,
+                "strongBiometricOnly");
+        assertTrue(config.isStrongBiometricOnly());
+    }
+
+    @Test
+    public void custom_biometricType_biometricOrDeviceCredential() {
+        FlutterSecureStorageConfig config = configFrom(FlutterSecureStorageConfig.PREF_OPTION_BIOMETRIC_TYPE,
+                "biometricOrDeviceCredential");
+        assertFalse(config.isStrongBiometricOnly());
+    }
+
+    @Test
+    public void biometricType_invalidValue_throwsIllegalArgumentException() {
+        try {
+            configFrom(FlutterSecureStorageConfig.PREF_OPTION_BIOMETRIC_TYPE, "invalidType");
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertTrue(e.getMessage().contains("invalidType"));
+        }
     }
 
     @Test

--- a/flutter_secure_storage/android/src/test/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorageConfigTest.java
+++ b/flutter_secure_storage/android/src/test/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorageConfigTest.java
@@ -153,6 +153,17 @@ public class FlutterSecureStorageConfigTest {
     }
 
     @Test
+    public void defaults_biometricPromptNegativeButton() {
+        assertEquals("Cancel", emptyConfig().getBiometricPromptNegativeButton());
+    }
+
+    @Test
+    public void custom_biometricPromptNegativeButton() {
+        FlutterSecureStorageConfig config = configFrom(FlutterSecureStorageConfig.PREF_OPTION_BIOMETRIC_PROMPT_NEGATIVE_BUTTON, "Dismiss");
+        assertEquals("Dismiss", config.getBiometricPromptNegativeButton());
+    }
+
+    @Test
     public void custom_biometricPromptTitle() {
         FlutterSecureStorageConfig config = configFrom(FlutterSecureStorageConfig.PREF_OPTION_BIOMETRIC_PROMPT_TITLE, "Please authenticate");
         assertEquals("Please authenticate", config.getBiometricPromptTitle());

--- a/flutter_secure_storage/lib/options/android_options.dart
+++ b/flutter_secure_storage/lib/options/android_options.dart
@@ -40,6 +40,19 @@ enum StorageCipherAlgorithm {
   AES_GCM_NoPadding,
 }
 
+/// Controls which authentication methods are accepted when biometric
+/// authentication is used.
+enum AndroidBiometricType {
+  /// Only Class 3 (strong) biometrics are accepted — e.g. fingerprint or
+  /// hardware-backed face recognition. Device credentials (PIN, pattern,
+  /// password) are explicitly rejected.
+  strongBiometricOnly,
+
+  /// Strong biometrics **or** device credentials (PIN, pattern, password) are
+  /// accepted. This is the default.
+  biometricOrDeviceCredential,
+}
+
 /// Specific options for Android platform.
 class AndroidOptions extends Options {
   /// Standard secure storage using AES-GCM with RSA OAEP key wrapping.
@@ -72,6 +85,8 @@ class AndroidOptions extends Options {
         KeyCipherAlgorithm.RSA_ECB_OAEPwithSHA_256andMGF1Padding,
     StorageCipherAlgorithm storageCipherAlgorithm =
         StorageCipherAlgorithm.AES_GCM_NoPadding,
+    AndroidBiometricType biometricType =
+        AndroidBiometricType.biometricOrDeviceCredential,
     @Deprecated(
         'Use storageNamespace instead. sharedPreferencesName only isolates '
         'data storage; storageNamespace provides full isolation including '
@@ -87,7 +102,8 @@ class AndroidOptions extends Options {
         _migrateWithBackup = migrateWithBackup,
         _enforceBiometrics = enforceBiometrics,
         _keyCipherAlgorithm = keyCipherAlgorithm,
-        _storageCipherAlgorithm = storageCipherAlgorithm;
+        _storageCipherAlgorithm = storageCipherAlgorithm,
+        _biometricType = biometricType;
 
   /// Maximum security storage with optional biometric authentication.
   /// - Optionally requires biometric authentication
@@ -107,6 +123,8 @@ class AndroidOptions extends Options {
     bool migrateOnAlgorithmChange = true,
     bool migrateWithBackup = false,
     bool enforceBiometrics = false,
+    AndroidBiometricType biometricType =
+        AndroidBiometricType.biometricOrDeviceCredential,
     @Deprecated(
         'Use storageNamespace instead. sharedPreferencesName only isolates '
         'data storage; storageNamespace provides full isolation including '
@@ -122,7 +140,8 @@ class AndroidOptions extends Options {
         _migrateWithBackup = migrateWithBackup,
         _enforceBiometrics = enforceBiometrics,
         _keyCipherAlgorithm = KeyCipherAlgorithm.AES_GCM_NoPadding,
-        _storageCipherAlgorithm = StorageCipherAlgorithm.AES_GCM_NoPadding;
+        _storageCipherAlgorithm = StorageCipherAlgorithm.AES_GCM_NoPadding,
+        _biometricType = biometricType;
 
   /// EncryptedSharedPrefences are only available on API 23 and greater
   final bool _encryptedSharedPreferences;
@@ -175,6 +194,10 @@ class AndroidOptions extends Options {
   /// By default AES/GCM/NoPadding is used (API 23+).
   /// Legacy AES/CBC/PKCS7Padding is available for backwards compatibility.
   final StorageCipherAlgorithm _storageCipherAlgorithm;
+
+  /// Controls which authentication methods are accepted during biometric
+  /// prompts.
+  final AndroidBiometricType _biometricType;
 
   /// The name of the sharedPreference database to use.
   /// You can select your own name if you want. A default name will
@@ -230,6 +253,7 @@ class AndroidOptions extends Options {
         'enforceBiometrics': '$_enforceBiometrics',
         'keyCipherAlgorithm': _keyCipherAlgorithm.name,
         'storageCipherAlgorithm': _storageCipherAlgorithm.name,
+        'biometricType': _biometricType.name,
         // ignore: deprecated_member_use_from_same_package — legacy support
         'sharedPreferencesName': sharedPreferencesName ?? '',
         'preferencesKeyPrefix': preferencesKeyPrefix ?? '',
@@ -249,6 +273,7 @@ class AndroidOptions extends Options {
     bool? enforceBiometrics,
     KeyCipherAlgorithm? keyCipherAlgorithm,
     StorageCipherAlgorithm? storageCipherAlgorithm,
+    AndroidBiometricType? biometricType,
     String? preferencesKeyPrefix,
     @Deprecated(
         'Use storageNamespace instead. sharedPreferencesName only isolates '
@@ -271,6 +296,7 @@ class AndroidOptions extends Options {
         keyCipherAlgorithm: keyCipherAlgorithm ?? _keyCipherAlgorithm,
         storageCipherAlgorithm:
             storageCipherAlgorithm ?? _storageCipherAlgorithm,
+        biometricType: biometricType ?? _biometricType,
         // ignore: deprecated_member_use_from_same_package — legacy support
         sharedPreferencesName:
             // ignore: deprecated_member_use_from_same_package — legacy support

--- a/flutter_secure_storage/lib/options/android_options.dart
+++ b/flutter_secure_storage/lib/options/android_options.dart
@@ -96,6 +96,7 @@ class AndroidOptions extends Options {
     this.storageNamespace,
     this.biometricPromptTitle,
     this.biometricPromptSubtitle,
+    this.biometricPromptNegativeButton,
   })  : _encryptedSharedPreferences = encryptedSharedPreferences,
         _resetOnError = resetOnError,
         _migrateOnAlgorithmChange = migrateOnAlgorithmChange,
@@ -134,6 +135,7 @@ class AndroidOptions extends Options {
     this.storageNamespace,
     this.biometricPromptTitle,
     this.biometricPromptSubtitle,
+    this.biometricPromptNegativeButton,
   })  : _encryptedSharedPreferences = encryptedSharedPreferences,
         _resetOnError = resetOnError,
         _migrateOnAlgorithmChange = migrateOnAlgorithmChange,
@@ -241,6 +243,13 @@ class AndroidOptions extends Options {
   /// The subtitle shown in the biometric authentication prompt.
   final String? biometricPromptSubtitle;
 
+  /// The label for the negative (cancel) button shown in the biometric prompt.
+  ///
+  /// Required when [biometricType] is [AndroidBiometricType.strongBiometricOnly]
+  /// or on Android 10 (API level 29) and lower, because device-credential
+  /// fallback is unavailable and the system needs an explicit dismiss action.
+  final String? biometricPromptNegativeButton;
+
   /// Default Android options with standard secure configuration.
   static const AndroidOptions defaultOptions = AndroidOptions();
 
@@ -262,6 +271,7 @@ class AndroidOptions extends Options {
             biometricPromptTitle ?? 'Authenticate to access',
         'biometricPromptSubtitle':
             biometricPromptSubtitle ?? 'Use biometrics or device credentials',
+        'biometricPromptNegativeButton': biometricPromptNegativeButton ?? 'Cancel',
       };
 
   /// Creates a copy of this AndroidOptions with the given fields replaced.
@@ -283,6 +293,7 @@ class AndroidOptions extends Options {
     String? storageNamespace,
     String? biometricPromptTitle,
     String? biometricPromptSubtitle,
+    String? biometricPromptNegativeButton,
   }) =>
       AndroidOptions(
         // ignore: deprecated_member_use_from_same_package — will be removed in v11
@@ -306,5 +317,7 @@ class AndroidOptions extends Options {
         biometricPromptTitle: biometricPromptTitle ?? this.biometricPromptTitle,
         biometricPromptSubtitle:
             biometricPromptSubtitle ?? this.biometricPromptSubtitle,
+        biometricPromptNegativeButton:
+            biometricPromptNegativeButton ?? this.biometricPromptNegativeButton,
       );
 }

--- a/flutter_secure_storage/lib/options/android_options.dart
+++ b/flutter_secure_storage/lib/options/android_options.dart
@@ -245,9 +245,9 @@ class AndroidOptions extends Options {
 
   /// The label for the negative (cancel) button shown in the biometric prompt.
   ///
-  /// Required when [biometricType] is [AndroidBiometricType.strongBiometricOnly]
-  /// or on Android 10 (API level 29) and lower, because device-credential
-  /// fallback is unavailable and the system needs an explicit dismiss action.
+  /// Required when [AndroidBiometricType.strongBiometricOnly] is used, or on
+  /// Android 10 (API level 29) and lower, because device-credential fallback
+  /// is unavailable and the system needs an explicit dismiss action.
   final String? biometricPromptNegativeButton;
 
   /// Default Android options with standard secure configuration.
@@ -271,7 +271,8 @@ class AndroidOptions extends Options {
             biometricPromptTitle ?? 'Authenticate to access',
         'biometricPromptSubtitle':
             biometricPromptSubtitle ?? 'Use biometrics or device credentials',
-        'biometricPromptNegativeButton': biometricPromptNegativeButton ?? 'Cancel',
+        'biometricPromptNegativeButton':
+            biometricPromptNegativeButton ?? 'Cancel',
       };
 
   /// Creates a copy of this AndroidOptions with the given fields replaced.

--- a/flutter_secure_storage/test/flutter_secure_storage_test.dart
+++ b/flutter_secure_storage/test/flutter_secure_storage_test.dart
@@ -387,6 +387,7 @@ void main() {
         'storageNamespace': '',
         'biometricPromptTitle': 'Authenticate to access',
         'biometricPromptSubtitle': 'Use biometrics or device credentials',
+        'biometricPromptNegativeButton': 'Cancel',
       });
     });
 
@@ -426,6 +427,7 @@ void main() {
         'storageNamespace': 'customPrefs',
         'biometricPromptTitle': 'Custom Title',
         'biometricPromptSubtitle': 'Custom Subtitle',
+        'biometricPromptNegativeButton': 'Cancel',
       });
     });
 
@@ -447,6 +449,7 @@ void main() {
         'storageNamespace': '',
         'biometricPromptTitle': 'Authenticate to access',
         'biometricPromptSubtitle': 'Use biometrics or device credentials',
+        'biometricPromptNegativeButton': 'Cancel',
       });
     });
 
@@ -473,6 +476,7 @@ void main() {
         'storageNamespace': '',
         'biometricPromptTitle': 'Unlock Secure Storage',
         'biometricPromptSubtitle': 'Verify your identity',
+        'biometricPromptNegativeButton': 'Cancel',
       });
     });
 
@@ -541,6 +545,7 @@ void main() {
         'storageNamespace': 'newPrefs',
         'biometricPromptTitle': 'New Title',
         'biometricPromptSubtitle': 'New Subtitle',
+        'biometricPromptNegativeButton': 'Cancel',
       });
     });
 

--- a/flutter_secure_storage/test/flutter_secure_storage_test.dart
+++ b/flutter_secure_storage/test/flutter_secure_storage_test.dart
@@ -705,12 +705,15 @@ void main() {
       }
     });
 
-    test('AndroidOptions.biometric with strongBiometricOnly sets biometricType', () {
-      const options = AndroidOptions.biometric(
-        biometricType: AndroidBiometricType.strongBiometricOnly,
-      );
-      expect(options.toMap()['biometricType'], 'strongBiometricOnly');
-    });
+    test(
+      'AndroidOptions.biometric with strongBiometricOnly sets biometricType',
+      () {
+        const options = AndroidOptions.biometric(
+          biometricType: AndroidBiometricType.strongBiometricOnly,
+        );
+        expect(options.toMap()['biometricType'], 'strongBiometricOnly');
+      },
+    );
 
     test('copyWith can change biometricType', () {
       const original = AndroidOptions.biometric();

--- a/flutter_secure_storage/test/flutter_secure_storage_test.dart
+++ b/flutter_secure_storage/test/flutter_secure_storage_test.dart
@@ -381,6 +381,7 @@ void main() {
         'enforceBiometrics': 'false',
         'keyCipherAlgorithm': 'RSA_ECB_OAEPwithSHA_256andMGF1Padding',
         'storageCipherAlgorithm': 'AES_GCM_NoPadding',
+        'biometricType': 'biometricOrDeviceCredential',
         'sharedPreferencesName': '',
         'preferencesKeyPrefix': '',
         'storageNamespace': '',
@@ -419,6 +420,7 @@ void main() {
         'enforceBiometrics': 'true',
         'keyCipherAlgorithm': 'RSA_ECB_PKCS1Padding',
         'storageCipherAlgorithm': 'AES_CBC_PKCS7Padding',
+        'biometricType': 'biometricOrDeviceCredential',
         'sharedPreferencesName': '',
         'preferencesKeyPrefix': 'customPrefix',
         'storageNamespace': 'customPrefs',
@@ -439,6 +441,7 @@ void main() {
         'enforceBiometrics': 'false',
         'keyCipherAlgorithm': 'AES_GCM_NoPadding',
         'storageCipherAlgorithm': 'AES_GCM_NoPadding',
+        'biometricType': 'biometricOrDeviceCredential',
         'sharedPreferencesName': '',
         'preferencesKeyPrefix': '',
         'storageNamespace': '',
@@ -464,6 +467,7 @@ void main() {
         'enforceBiometrics': 'true',
         'keyCipherAlgorithm': 'AES_GCM_NoPadding',
         'storageCipherAlgorithm': 'AES_GCM_NoPadding',
+        'biometricType': 'biometricOrDeviceCredential',
         'sharedPreferencesName': '',
         'preferencesKeyPrefix': '',
         'storageNamespace': '',
@@ -531,6 +535,7 @@ void main() {
         'enforceBiometrics': 'true',
         'keyCipherAlgorithm': 'RSA_ECB_PKCS1Padding',
         'storageCipherAlgorithm': 'AES_CBC_PKCS7Padding',
+        'biometricType': 'biometricOrDeviceCredential',
         'sharedPreferencesName': '',
         'preferencesKeyPrefix': 'newPrefix',
         'storageNamespace': 'newPrefs',
@@ -686,6 +691,29 @@ void main() {
         final options = AndroidOptions(storageCipherAlgorithm: algorithm);
         expect(options.toMap()['storageCipherAlgorithm'], algorithm.name);
       }
+    });
+
+    test('All AndroidBiometricType enum values are correctly mapped', () {
+      for (final type in AndroidBiometricType.values) {
+        final options = AndroidOptions(biometricType: type);
+        expect(options.toMap()['biometricType'], type.name);
+      }
+    });
+
+    test('AndroidOptions.biometric with strongBiometricOnly sets biometricType', () {
+      const options = AndroidOptions.biometric(
+        biometricType: AndroidBiometricType.strongBiometricOnly,
+      );
+      expect(options.toMap()['biometricType'], 'strongBiometricOnly');
+    });
+
+    test('copyWith can change biometricType', () {
+      const original = AndroidOptions.biometric();
+      final copied = original.copyWith(
+        biometricType: AndroidBiometricType.strongBiometricOnly,
+      );
+      expect(copied.toMap()['biometricType'], 'strongBiometricOnly');
+      expect(original.toMap()['biometricType'], 'biometricOrDeviceCredential');
     });
   });
 


### PR DESCRIPTION
Hi, thank you for always providing the great package!
I'd like to add an option to restrict authentication on Android. I would appreciate it if you could consider this.

## Motivation

  AndroidOptions.biometric() previously accepted both Class 3 (strong) biometrics and device credentials (PIN, pattern, password) with no way to restrict to biometrics alone. Users who need strict biometric-only
  access — e.g. storing a secret that should not be unlockable with a PIN — had no supported path.

  ## What

  Two new options on AndroidOptions and AndroidOptions.biometric():

  - biometricType: AndroidBiometricType (**default: biometricOrDeviceCredential**)
    - biometricOrDeviceCredential — preserves existing behaviour: strong biometrics or device credentials are accepted
    - strongBiometricOnly — restricts to Class 3 biometrics only; device credentials are explicitly rejected everywhere: BiometricManager.canAuthenticate, BiometricPrompt.setAllowedAuthenticators, and
  KeyGenParameterSpec.setUserAuthenticationParameters. Fully enforced on API 30+; best-effort on API 28–29.
  - biometricPromptNegativeButton (default: "Cancel") — the label for the dismiss button on the biometric prompt. Required when using strongBiometricOnly (no device-credential fallback means no implicit dismiss
  action) or on Android 10 (API level 29) and lower where setAllowedAuthenticators is unavailable and a negative button is always needed.

I think it's related to #1125.