### PR TITLE
fix: reset stale cipher IV when biometric auth fails or is cancelled

### DIFF
--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationAES23.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationAES23.java
@@ -99,14 +99,11 @@ class KeyCipherImplementationAES23 implements KeyCipher {
         } else {
             // IV missing, or IV exists but app key doesn't (stale from a failed/cancelled auth).
             // Start fresh with a new ENCRYPT cipher.
-            if (ivBase64 != null) {
-                preferences.edit().remove(SHARED_PREFERENCES_KEY).apply();
-            }
             cipher.init(Cipher.ENCRYPT_MODE, key);
 
             byte[] iv = cipher.getIV();
             SharedPreferences.Editor editor = preferences.edit();
-            editor.putString(SHARED_PREFERENCES_KEY,  Base64.encodeToString(iv, Base64.DEFAULT));
+            editor.putString(SHARED_PREFERENCES_KEY, Base64.encodeToString(iv, Base64.DEFAULT));
             editor.apply();
         }
 

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationAES23.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationAES23.java
@@ -92,12 +92,16 @@ class KeyCipherImplementationAES23 implements KeyCipher {
         SharedPreferences preferences = context.getSharedPreferences(config.getEffectiveKeyStoragePrefsName(), Context.MODE_PRIVATE);
         String ivBase64 = preferences.getString(SHARED_PREFERENCES_KEY, null);
 
-        if (ivBase64 != null) {
-            byte[] iv =  Base64.decode(ivBase64, Base64.DEFAULT);
-
+        if (ivBase64 != null && StorageCipherImplementationAES23.hasApplicationKey(preferences)) {
+            byte[] iv = Base64.decode(ivBase64, Base64.DEFAULT);
             GCMParameterSpec spec = new GCMParameterSpec(IV_SIZE * Byte.SIZE, iv);
             cipher.init(Cipher.DECRYPT_MODE, key, spec);
         } else {
+            // IV missing, or IV exists but app key doesn't (stale from a failed/cancelled auth).
+            // Start fresh with a new ENCRYPT cipher.
+            if (ivBase64 != null) {
+                preferences.edit().remove(SHARED_PREFERENCES_KEY).apply();
+            }
             cipher.init(Cipher.ENCRYPT_MODE, key);
 
             byte[] iv = cipher.getIV();

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherImplementationAES23.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherImplementationAES23.java
@@ -32,6 +32,10 @@ public class StorageCipherImplementationAES23 implements StorageCipher {
         this.cipher = getCipher();
     }
 
+    static boolean hasApplicationKey(SharedPreferences preferences) {
+        return preferences.contains(KEYSTORE_IV_NAME);
+    }
+
     private SecretKey loadOrGenerateApplicationKey(Context context, Cipher biometricCipher) throws Exception {
         final Cipher cipher = (biometricCipher != null) ? biometricCipher : getCipher();
         assert (cipher != null);


### PR DESCRIPTION
Hi, thank you for your review last time!
While using the example app, I noticed a few things, so I’d appreciate it if you could take a look at them.

### Steps to reproduce:

1. Install the example app with AndroidOptions.biometric().
2. Launch the app — the biometric prompt appears. Cancel it (e.g. tap the back button).
3. Relaunch the app — the biometric prompt appears again. Authenticate successfully.
4. The app cannot read stored data → KeyStoreException.

```

E/FlutterSecureStorage(29631): Failed to initialize storage cipher after authentication
E/FlutterSecureStorage(29631): javax.crypto.AEADBadTagException
E/FlutterSecureStorage(29631): 	at android.security.keystore2.AndroidKeyStoreCipherSpiBase.engineDoFinal(AndroidKeyStoreCipherSpiBase.java:626)
E/FlutterSecureStorage(29631): 	at javax.crypto.Cipher.doFinal(Cipher.java:2056)
E/FlutterSecureStorage(29631): 	at com.it_nomads.fluttersecurestorage.ciphers.StorageCipherImplementationAES23.loadOrGenerateApplicationKey(StorageCipherImplementationAES23.java:51)
E/FlutterSecureStorage(29631): 	at com.it_nomads.fluttersecurestorage.ciphers.StorageCipherImplementationAES23.<init>(StorageCipherImplementationAES23.java:31)
E/FlutterSecureStorage(29631): 	at com.it_nomads.fluttersecurestorage.ciphers.StorageCipherFactory.createStorageCipher(StorageCipherFactory.java:90)
E/FlutterSecureStorage(29631): 	at com.it_nomads.fluttersecurestorage.ciphers.StorageCipherFactory.getCurrentStorageCipher(StorageCipherFactory.java:77)
E/FlutterSecureStorage(29631): 	at com.it_nomads.fluttersecurestorage.FlutterSecureStorage$2.onSuccess(FlutterSecureStorage.java:291)
E/FlutterSecureStorage(29631): 	at com.it_nomads.fluttersecurestorage.FlutterSecureStorage$2.onSuccess(FlutterSecureStorage.java:287)
E/FlutterSecureStorage(29631): 	at com.it_nomads.fluttersecurestorage.FlutterSecureStorage$7.onAuthenticationSucceeded(FlutterSecureStorage.java:1163)
E/FlutterSecureStorage(29631): 	at android.hardware.biometrics.BiometricPrompt$1.lambda$onAuthenticationSucceeded$0(BiometricPrompt.java:530)
E/FlutterSecureStorage(29631): 	at android.hardware.biometrics.BiometricPrompt$1.$r8$lambda$C_QZKc4FnF78mxFp_6BBMbs-7xI(Unknown Source:0)
E/FlutterSecureStorage(29631): 	at android.hardware.biometrics.BiometricPrompt$1$$ExternalSyntheticLambda4.run(Unknown Source:4)
E/FlutterSecureStorage(29631): 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
E/FlutterSecureStorage(29631): 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
E/FlutterSecureStorage(29631): 	at java.lang.Thread.run(Thread.java:1012)
E/FlutterSecureStorage(29631): Caused by: android.security.KeyStoreException: Signature/MAC verification failed (internal Keystore code: -30 message: system/security/keystore2/src/operation.rs:850: KeystoreOperation::finish
E/FlutterSecureStorage(29631): 
E/FlutterSecureStorage(29631): Caused by:
E/FlutterSecureStorage(29631):     0: system/security/keystore2/src/operation.rs:426: Finish failed.
E/FlutterSecureStorage(29631):     1: Error::Km(r#VERIFICATION_FAILED)) (public error code: 10 internal Keystore code: -30)
E/FlutterSecureStorage(29631): 	at android.security.KeyStore2.getKeyStoreException(KeyStore2.java:386)
E/FlutterSecureStorage(29631): 	at android.security.KeyStoreOperation.handleExceptions(KeyStoreOperation.java:78)
E/FlutterSecureStorage(29631): 	at android.security.KeyStoreOperation.finish(KeyStoreOperation.java:128)
E/FlutterSecureStorage(29631): 	at android.security.keystore2.KeyStoreCryptoOperationChunkedStreamer$MainDataStream.finish(KeyStoreCryptoOperationChunkedStreamer.java:228)
E/FlutterSecureStorage(29631): 	at android.security.keystore2.KeyStoreCryptoOperationChunkedStreamer.doFinal(KeyStoreCryptoOperationChunkedStreamer.java:181)
E/FlutterSecureStorage(29631): 	at android.security.keystore2.AndroidKeyStoreAuthenticatedAESCipherSpi$BufferAllOutputUntilDoFinalStreamer.doFinal(AndroidKeyStoreAuthenticatedAESCipherSpi.java:396)
E/FlutterSecureStorage(29631): 	at android.security.keystore2.AndroidKeyStoreCipherSpiBase.engineDoFinal(AndroidKeyStoreCipherSpiBase.java:618)
E/FlutterSecureStorage(29631): 	... 14 more
```

### What

getCipher() now checks both the IV and the presence of the encrypted app key (StorageCipherImplementationAES23.hasApplicationKey()) before entering DECRYPT mode. If the IV exists without a corresponding app key, the stale IV is cleared and the cipher is re-initialized in ENCRYPT mode.