### PR TITLE
fix: defer preferences assignment until cipher initialization succeeds

### DIFF
--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
@@ -248,8 +248,18 @@ public class FlutterSecureStorage {
             if (config.isUseEncryptedSharedPreferences() && isAlreadyMigrated) {
                 Log.i(TAG, "Data already migrated, encryptedSharedPreferences ignored and can be safely removed.");
             }
-            preferences = nonEncryptedPreferences;
-            initializeStorageCipher(configSource, callback);
+            initializeStorageCipher(configSource, new SecurePreferencesCallback<>() {
+                @Override
+                public void onSuccess(Void unused) {
+                    preferences = nonEncryptedPreferences;
+                    callback.onSuccess(null);
+                }
+
+                @Override
+                public void onError(Exception e) {
+                    callback.onError(e);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
### Steps to reproduce

1. Install the example app with AndroidOptions.biometric().
2. Launch the app — the biometric prompt appears. Cancel it (e.g. tap the back button).
3. Tap the + button (or any action that triggers the biometric prompt).
4. No prompt appears and nothing happens.

```
E/FlutterSecureStorage(30597): java.lang.NullPointerException: Attempt to invoke interface method 'byte[] com.it_nomads.fluttersecurestorage.ciphers.StorageCipher.encrypt(byte[])' on a null object reference
E/FlutterSecureStorage(30597): 	at com.it_nomads.fluttersecurestorage.FlutterSecureStorage.writeUnsafe(FlutterSecureStorage.java:128)
E/FlutterSecureStorage(30597): 	at com.it_nomads.fluttersecurestorage.FlutterSecureStorage.write(FlutterSecureStorage.java:112)
E/FlutterSecureStorage(30597): 	at com.it_nomads.fluttersecurestorage.FlutterSecureStoragePlugin$MethodRunner$1.onSuccess(FlutterSecureStoragePlugin.java:178)
E/FlutterSecureStorage(30597): 	at com.it_nomads.fluttersecurestorage.FlutterSecureStoragePlugin$MethodRunner$1.onSuccess(FlutterSecureStoragePlugin.java:168)
E/FlutterSecureStorage(30597): 	at com.it_nomads.fluttersecurestorage.FlutterSecureStorage.initialize(FlutterSecureStorage.java:148)
E/FlutterSecureStorage(30597): 	at com.it_nomads.fluttersecurestorage.FlutterSecureStoragePlugin$MethodRunner.run(FlutterSecureStoragePlugin.java:168)
E/FlutterSecureStorage(30597): 	at android.os.Handler.handleCallback(Handler.java:958)
E/FlutterSecureStorage(30597): 	at android.os.Handler.dispatchMessage(Handler.java:99)
E/FlutterSecureStorage(30597): 	at android.os.Looper.loopOnce(Looper.java:205)
E/FlutterSecureStorage(30597): 	at android.os.Looper.loop(Looper.java:294)
E/FlutterSecureStorage(30597): 	at android.os.HandlerThread.run(HandlerThread.java:67)
```

### What

Moved the preferences assignment to after `initializeStorageCipher` completes successfully, so both preferences and storageCipher are set atomically. A cancelled or failed initialization leaves both null, allowing the next call to retry cleanly.  The migration path (e.g. L207/213) already assigned preferences inside the `initializeStorageCipher `callback, so this fix applies the same approach.