### PR TITLE
fix: remove redundant ./ prefix from part directives

### DIFF
--- a/flutter_secure_storage/lib/flutter_secure_storage.dart
+++ b/flutter_secure_storage/lib/flutter_secure_storage.dart
@@ -7,13 +7,13 @@ import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
 import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
 
-part './options/android_options.dart';
-part './options/apple_options.dart';
-part './options/linux_options.dart';
-part './options/web_options.dart';
-part './options/windows_options.dart';
-part './options/ios_options.dart';
-part './options/macos_options.dart';
+part 'options/android_options.dart';
+part 'options/apple_options.dart';
+part 'options/linux_options.dart';
+part 'options/web_options.dart';
+part 'options/windows_options.dart';
+part 'options/ios_options.dart';
+part 'options/macos_options.dart';
 
 final Map<String, List<ValueChanged<String?>>> _listeners = {};
 

--- a/flutter_secure_storage_platform_interface/lib/flutter_secure_storage_platform_interface.dart
+++ b/flutter_secure_storage_platform_interface/lib/flutter_secure_storage_platform_interface.dart
@@ -4,8 +4,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
-part './src/method_channel_flutter_secure_storage.dart';
-part './src/options.dart';
+part 'src/method_channel_flutter_secure_storage.dart';
+part 'src/options.dart';
 
 /// The interface that implementations of flutter_secure_storage must implement.
 ///


### PR DESCRIPTION
Resolves flutter analyze style warnings about unnecessary leading ./ in relative path references.

Related to https://github.com/juliansteenbakker/flutter_secure_storage/actions/runs/27863908065/job/82464593497.