### PR TITLE
chore: correct release-please bootstrap tracking

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   "flutter_secure_storage": "11.0.0-beta.1",
   "flutter_secure_storage_platform_interface": "2.0.1",
-  "flutter_secure_storage_darwin": "0.4.0",
+  "flutter_secure_storage_darwin": "0.4.1",
   "flutter_secure_storage_linux": "3.0.1",
   "flutter_secure_storage_web": "2.1.1",
   "flutter_secure_storage_windows": "4.2.2"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "flutter_secure_storage": "11.0.0-beta.1",
-  "flutter_secure_storage_platform_interface": "2.0.1",
+  "flutter_secure_storage_platform_interface": "2.0.2",
   "flutter_secure_storage_darwin": "0.4.1",
   "flutter_secure_storage_linux": "3.0.1",
   "flutter_secure_storage_web": "2.1.1",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,9 @@ melos bootstrap
 
 ## Versioning
 
-Each package in this repo (`flutter_secure_storage`, `flutter_secure_storage_platform_interface`, `flutter_secure_storage_darwin`, `flutter_secure_storage_linux`, `flutter_secure_storage_web`, `flutter_secure_storage_windows`) is versioned independently. If your PR changes a package's public behavior:
+Each package in this repo (`flutter_secure_storage`, `flutter_secure_storage_platform_interface`, `flutter_secure_storage_darwin`, `flutter_secure_storage_linux`, `flutter_secure_storage_web`, `flutter_secure_storage_windows`) is versioned independently, and releases are handled automatically by [Release Please](https://github.com/googleapis/release-please). **Please don't bump a `pubspec.yaml` version or add a `CHANGELOG.md` entry yourself** — Release Please generates both from your commit messages after merge.
 
-1. Bump the version in that package's `pubspec.yaml`.
-2. Add a changelog entry at the top of that package's `CHANGELOG.md`.
-3. If you bumped a platform package (darwin/linux/web/windows), also check whether the `^` constraint on it in `flutter_secure_storage/pubspec.yaml` needs updating.
+1. Scope your commit/PR title to the package(s) you actually changed, e.g. `fix(darwin): ...`, `feat(windows): ...`. Release Please uses the Conventional Commit type (and scope) to decide which package(s) get a version bump and what the changelog entry says.
+2. Try not to mix changes to multiple packages in a single commit — Release Please attributes a commit, including any `!` breaking-change marker, to every package whose files it touches, so an unrelated multi-package commit can trigger an unintended version bump elsewhere.
+3. Once merged, Release Please opens a `chore(develop): release <package> X.Y.Z` PR for each affected package. Merging that PR cuts the release, tags it `<package-directory>-vX.Y.Z` (this applies to all six packages, including the main `flutter_secure_storage`), and publishes it to pub.dev via CI.
+4. If you bumped a platform package (darwin/linux/web/windows), also check whether the `^` constraint on it in `flutter_secure_storage/pubspec.yaml` needs updating — that's still a manual step.

--- a/flutter_secure_storage_platform_interface/CHANGELOG.md
+++ b/flutter_secure_storage_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.2
+Remove redundant `./` prefix from part directives.
+
 ## 2.0.1
 Remove dart:io to support WASM build of web.
 

--- a/flutter_secure_storage_platform_interface/pubspec.yaml
+++ b/flutter_secure_storage_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_secure_storage_platform_interface
 description: A common platform interface for the flutter_secure_storage plugin.
 homepage: https://github.com/mogol/flutter_secure_storage
-version: 2.0.1
+version: 2.0.2
 resolution: workspace
 
 environment:


### PR DESCRIPTION
## Summary
release-please was bootstrapped (#1185) without git tags matching its `<component>-vX.Y.Z` expectation, and two historical commits (`87198bc`, `70e983e`) touched multiple packages' `pubspec.yaml` while carrying a breaking-change marker scoped to only one of them. Together these caused PRs #1187–#1192 to propose inflated/duplicate-content releases for all six packages.

This PR corrects the two packages whose *tracked* state doesn't match reality before tags get backfilled:

- **darwin**: manifest said `0.4.0`, but `0.4.1` is what's actually published (bumped manually in `2323266`, outside release-please). Manifest-only fix, no code change, no new release.
- **platform_interface**: the only genuinely new, correctly-scoped change since `2.0.1` is "remove redundant `./` prefix from part directives" (`cc7018d`/`bc15a90`) — a patch, not the `3.0.0` major the stale PR proposed. Bumps to `2.0.2` with an accurate changelog entry.
- Also updates `CONTRIBUTING.md`'s versioning section, which still described manual version bumping even though release-please now owns that.

`web`, `linux`, `windows`, and the main package aren't touched here — once tags are backfilled at their real last-release commits, those will regenerate cleanly on their own with no manual override needed.

## Test plan
- [ ] Merge this PR
- [ ] Backfill the 6 `<component>-vX.Y.Z` tags (platform_interface's tag points at this PR's merge commit; darwin's points at `2323266`)
- [ ] Close #1187–#1192 and delete their branches
- [ ] Confirm the next release-please run opens no PR for darwin/web/linux/platform_interface, and only genuinely-new content for main/windows