### PR TITLE
fix: publish workflow tag patterns never matched real tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,12 +8,12 @@ name: Publish to pub.dev
 on:
   push:
     tags:
-      - "flutter_secure_storage-v[0-9]+.[0-9]+.[0-9]+*"
-      - "flutter_secure_storage_platform_interface-v[0-9]+.[0-9]+.[0-9]+*"
-      - "flutter_secure_storage_darwin-v[0-9]+.[0-9]+.[0-9]+*"
-      - "flutter_secure_storage_linux-v[0-9]+.[0-9]+.[0-9]+*"
-      - "flutter_secure_storage_web-v[0-9]+.[0-9]+.[0-9]+*"
-      - "flutter_secure_storage_windows-v[0-9]+.[0-9]+.[0-9]+*"
+      - "flutter_secure_storage-v*"
+      - "flutter_secure_storage_platform_interface-v*"
+      - "flutter_secure_storage_darwin-v*"
+      - "flutter_secure_storage_linux-v*"
+      - "flutter_secure_storage_web-v*"
+      - "flutter_secure_storage_windows-v*"
 
 jobs:
   publish:


### PR DESCRIPTION
GitHub Actions tag filters use glob, not regex. [0-9]+ meant one digit then a literal +, so none of the release tags ever matched and publish.yml never ran. Switched to plain -v* wildcards.