### PR TITLE
feat(linux): support for XDG Desktop Secret Portal (org.freedesktop.portal.Secret)

### DIFF
--- a/flutter_secure_storage_linux_portal/CHANGELOG.md
+++ b/flutter_secure_storage_linux_portal/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+- Initial version.

--- a/flutter_secure_storage_linux_portal/README.md
+++ b/flutter_secure_storage_linux_portal/README.md
@@ -1,0 +1,23 @@
+A Linux implementation of [`flutter_secure_storage`](https://pub.dev/packages/flutter_secure_storage) using the XDG Desktop [Secret Portal API](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Secret.html) (`org.freedesktop.portal.Secret`).
+
+## Usage
+
+Register this implementation when the application should use the XDG Desktop
+Secret Portal API (`org.freedesktop.portal.Secret`), such as when running in a
+sandboxed environment (e.g., Flatpak or Snap).
+
+```dart
+import 'package:flutter_secure_storage_linux_portal/flutter_secure_storage_linux_portal.dart';
+
+FlutterSecureStorageLinuxPortal.registerWith();
+```
+
+## File Path
+
+Stores the secrets encrypted in [a file](https://pub.dev/packages/xdg_secret_portal_store#storage-format):
+
+`$XDG_DATA_HOME/$APPLICATION_ID/xdg_secret_portal_store/secrets.json`.
+
+## Cryptography
+
+For [security details](https://pub.dev/packages/xdg_secret_portal_store#cryptography).

--- a/flutter_secure_storage_linux_portal/lib/flutter_secure_storage_linux_portal.dart
+++ b/flutter_secure_storage_linux_portal/lib/flutter_secure_storage_linux_portal.dart
@@ -1,0 +1,121 @@
+import 'dart:io';
+
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:linux_application_id/linux_application_id.dart';
+import 'package:xdg_desktop_portal/xdg_desktop_portal.dart';
+import 'package:xdg_directories/xdg_directories.dart';
+import 'package:xdg_secret_portal_store/xdg_secret_portal_store.dart';
+import 'package:xdg_secret_portal_store_default/xdg_secret_portal_store_default.dart';
+
+typedef _StorageMap = Map<String, String>;
+
+/// Linux implementation of [FlutterSecureStoragePlatform] using the XDG
+/// Desktop Portal Secret API.
+class FlutterSecureStorageLinuxPortal extends FlutterSecureStoragePlatform {
+  /// Registers this class as the default instance of [FlutterSecureStoragePlatform].
+  static void registerWith() {
+    FlutterSecureStoragePlatform.instance = FlutterSecureStorageLinuxPortal();
+  }
+
+  late final XdgDesktopPortalClient _client;
+  late final XdgSecretPortalStore _store;
+  late String _applicationId;
+
+  Future<void>? _initialization;
+  Future<void> _initialize() async {
+    _applicationId =
+        applicationIdOverride ??
+        linuxApplicationId() ??
+        (throw UnsupportedError(
+          'No Linux application ID is available. This must be called from a running Flutter Linux application.',
+        ));
+
+    _client = XdgDesktopPortalClient();
+
+    final filePath =
+        '${dataHome.path}/$_applicationId/xdg_secret_portal_store/secrets.json';
+
+    _store = XdgSecretPortalStore(
+      masterSecretRetriever: _client.secret.retrieveSecret,
+      persistence: SecretStorePersistenceFile(File(filePath)),
+      crypto: SecretStoreCryptoDefault(),
+    );
+
+    await _store.loadMasterSecret();
+  }
+
+  Future<void> _ensureInitialized() => _initialization ??= _initialize();
+
+  /// Overrides the Linux application ID.
+  ///
+  /// The application ID is used to determine the directory where the encrypted
+  /// secret store is persisted.
+  String? applicationIdOverride;
+
+  Future<_StorageMap> _readStorageMap() => _store.read();
+  Future<void> _writeStorageMap(_StorageMap map) => _store.write(map);
+
+  @override
+  Future<bool> containsKey({
+    required String key,
+    required Map<String, String> options,
+  }) async {
+    await _ensureInitialized();
+    final map = await _readStorageMap();
+    return map.containsKey(key);
+  }
+
+  @override
+  Future<void> delete({
+    required String key,
+    required Map<String, String> options,
+  }) async {
+    await _ensureInitialized();
+
+    final map = await _readStorageMap();
+    map.remove(key);
+
+    await _writeStorageMap(map);
+  }
+
+  @override
+  Future<void> deleteAll({required Map<String, String> options}) async {
+    await _ensureInitialized();
+
+    await _writeStorageMap({});
+  }
+
+  @override
+  Future<String?> read({
+    required String key,
+    required Map<String, String> options,
+  }) async {
+    await _ensureInitialized();
+
+    final map = await _readStorageMap();
+    return map[key];
+  }
+
+  @override
+  Future<Map<String, String>> readAll({
+    required Map<String, String> options,
+  }) async {
+    await _ensureInitialized();
+
+    return _readStorageMap();
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) async {
+    await _ensureInitialized();
+
+    final map = await _readStorageMap();
+    map[key] = value;
+
+    await _writeStorageMap(map);
+  }
+}

--- a/flutter_secure_storage_linux_portal/pubspec.yaml
+++ b/flutter_secure_storage_linux_portal/pubspec.yaml
@@ -1,0 +1,18 @@
+name: flutter_secure_storage_linux_portal
+description: Linux implementation of flutter_secure_storage using the XDG Desktop Portal Secret API (org.freedesktop.portal.Secret)
+version: 0.0.1
+repository: https://github.com/juliansteenbakker/flutter_secure_storage/tree/develop/flutter_secure_storage_linux_portal
+issue_tracker: https://github.com/juliansteenbakker/flutter_secure_storage/issues/new?labels=linux
+topics: [os-integration, xdg-portal, secure-storage]
+
+environment:
+  sdk: '>=3.5.0 <4.0.0'
+  flutter: '>=3.19.0'
+
+dependencies:
+  flutter_secure_storage_platform_interface: ^2.0.1
+  xdg_desktop_portal: ^0.1.13
+  xdg_directories: ^1.1.0
+  xdg_secret_portal_store: ^0.2.0
+  xdg_secret_portal_store_default: ^0.1.1
+  linux_application_id: ^1.0.0


### PR DESCRIPTION
## Description

Fixes #1203

This PR creates a new package (`flutter_secure_storage_linux_portal`) for Secret Portal support. Details are in #1203

See also:

- https://pub.dev/packages/xdg_secret_portal_store#storage-format
- https://pub.dev/packages/xdg_secret_portal_store#not-interoperable-with-gnome-libsecret
- https://pub.dev/packages/xdg_secret_portal_store_default#cryptography (important)
- PR #1203

Usage from a consumer perspective:

```dart
import 'package:flutter_secure_storage/flutter_secure_storage.dart';
import 'package:flutter_secure_storage_linux_portal/flutter_secure_storage_linux_portal.dart';

void main() {
  // Apps need to detect Flatpak or Snap, and then call this method
  FlutterSecureStorageLinuxPortal.registerWith();
}
```

### Disclaimer

The [cryptographic implementation](https://github.com/EchoEllet/dart-packages/blob/main/packages/linux_secret_store/xdg_secret_portal_store_default/lib/src/secret_store_crypto_default.dart) was not reviewed by a security professional.

The cryptographic operations are implemented using
[`package:cryptography`](https://pub.dev/packages/cryptography).

Consider reading: https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Secret.html#org-freedesktop-portal-secret-retrievesecret

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
- [ ] Affected package(s) had their version bumped in `pubspec.yaml` and a changelog entry added to `CHANGELOG.md`.
