### PR TITLE
fix(android): catch Throwable on worker thread so keystore Errors don't crash the app

### DIFF
--- a/flutter_secure_storage/CHANGELOG.md
+++ b/flutter_secure_storage/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Android
+
+- Fixed a fatal app crash when Android Keystore framework code throws `java.lang.Error` subclasses (e.g. `NoSuchFieldError` on some OEM builds with mismatched framework/KeyMint classes): the plugin's worker thread now catches `Throwable` and reports a `PlatformException` to Dart instead of killing the process.
+
 ## 11.0.0-beta.1
 
 **Breaking changes**

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
@@ -188,9 +188,13 @@ public class FlutterSecureStorage {
                     try {
                         storageCipher = storageCipherFactory.getCurrentStorageCipher(context, result.getCryptoObject().getCipher());
                         Log.d(TAG, "Biometric authentication succeeded");
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
+                        if (e instanceof VirtualMachineError) {
+                            throw (VirtualMachineError) e;
+                        }
                         Log.e(TAG, "Failed to initialize storage cipher after authentication", e);
-                        callback.onError(e);
+                        callback.onError(new Exception(e));
+                        return;
                     }
                     callback.onSuccess(null);
                 }

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -230,12 +230,12 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                                 result.notImplemented();
                                 break;
                         }
-                    } catch (Exception e) {
+                    } catch (Throwable e) {
                         if (config.shouldDeleteOnFailure()) {
                             try {
                                 secureStorage.deleteAll();
                                 result.success("Data has been reset");
-                            } catch (Exception ex) {
+                            } catch (Throwable ex) {
                                 handleException(ex);
                             }
                         } else {
@@ -249,13 +249,17 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                     handleException(e);
                 }
             });
-            } catch (Exception e) {
+            } catch (Throwable e) {
+                // Catch Throwable, not just Exception: some OEM builds throw
+                // java.lang.Error subclasses (e.g. NoSuchFieldError) from Android
+                // Keystore framework code, and an uncaught Error on this
+                // HandlerThread would crash the entire app process.
                 handleException(e);
             }
         }
 
 
-        private void handleException(Exception e) {
+        private void handleException(Throwable e) {
             StringWriter stringWriter = new StringWriter();
             e.printStackTrace(new PrintWriter(stringWriter));
             // Send exception message as the message field so Flutter can parse it

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -231,6 +231,9 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                                 break;
                         }
                     } catch (Throwable e) {
+                        if (e instanceof VirtualMachineError) {
+                            throw (VirtualMachineError) e;
+                        }
                         if (config.shouldDeleteOnFailure()) {
                             try {
                                 secureStorage.deleteAll();
@@ -253,7 +256,13 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                 // Catch Throwable, not just Exception: some OEM builds throw
                 // java.lang.Error subclasses (e.g. NoSuchFieldError) from Android
                 // Keystore framework code, and an uncaught Error on this
-                // HandlerThread would crash the entire app process.
+                // HandlerThread would crash the entire app process. Genuine VM
+                // errors (OOM, StackOverflow) are rethrown instead of being
+                // funneled through handleException/deleteAll, which would
+                // allocate memory the JVM may no longer have.
+                if (e instanceof VirtualMachineError) {
+                    throw (VirtualMachineError) e;
+                }
                 handleException(e);
             }
         }


### PR DESCRIPTION
## Description

Fixes #1208.

On some OEM firmware builds (observed on Vivo, Android 12), the device's `framework.jar` and KeyMint HAL classes are mismatched, so any Android Keystore key generation throws `java.lang.NoSuchFieldError` from `android.security.keystore2.KeyStore2ParameterUtils`. Because `MethodRunner.run()` only caught `Exception`, this `Error` escaped the plugin's worker `HandlerThread` and killed the whole app process before anything reached the Dart side — app-level try/catch can never see it.

## Changes

- `FlutterSecureStoragePlugin.java`: widen the `MethodRunner.run()` outer catch, the per-operation catch, and the delete-on-failure retry catch from `Exception` to `Throwable`, and change `handleException` to accept `Throwable`.
- `CHANGELOG.md`: add an Unreleased entry.

No behavior change for normal exceptions — they flow through the exact same `handleException` → `result.error(...)` path as before. The only difference is that `Error` subclasses now also surface as a `PlatformException` to Dart instead of crashing the process.

On affected devices the keystore itself is broken (typically cleared by a reboot or firmware OTA), so storage operations may still fail — but apps can now catch the failure and degrade gracefully (e.g. re-prompt login) instead of crash-looping at startup.

## Notes

- The full analysis, including the v10.3.1 stack trace and why the same devices would also crash on `develop` via the custom cipher keygen path (`KeyCipherImplementationRSAOAEP` / `KeyCipherImplementationAES23` → `KeyGenerator`/`KeyPairGenerator` → same keystore2 framework path), is in #1208.
- Deliberately kept minimal: this worker-thread backstop alone converts the process crash into a catchable `PlatformException` for every keystore `Error` raised on this thread. Happy to also widen inner catches (e.g. around cipher initialization) if you'd prefer failures to fall through to internal fallback logic as well.
