### PR TITLE
ci: gate master promotion on no other pending release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,9 @@ jobs:
 
   # Once any package's release lands on develop, fast-track it onto master so
   # that hotfixes can always be branched from a branch that matches the
-  # latest published state.
+  # latest published state. Waits until no other package's release PR is
+  # still pending, otherwise their unreleased commits reach master early and
+  # release-please-master.yml mistakes them for master-side releases.
   promote-to-master:
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'
@@ -36,7 +38,20 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v7
+      - name: Skip promotion while other release PRs are still pending
+        id: gate
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          pending=$(gh pr list --base develop --label "autorelease: pending" --json number --jq length)
+          if [ "$pending" -gt 0 ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "$pending other release PR(s) still open on develop, skipping promotion for now."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Open and merge promotion PR into master
+        if: steps.gate.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary
- `promote-to-master` currently fires as soon as any single component's release PR merges, regardless of whether other components still have release PRs open on develop.
- Since each package releases independently (`separate-pull-requests: true`), merging one release PR while others are pending drags their unreleased commits onto master early. `release-please-master.yml` (intended for hotfixes) then mistakes those for master-side releases — this is exactly what happened with #1217 and #1218 after #1205 merged while #1198/#1206 were still open.
- This adds a guard step that checks for other `autorelease: pending` PRs open against develop and skips promotion until none remain, so the last one to merge triggers a clean, complete promotion.

## Test plan
- [ ] Merge a release PR while another release PR is still open on develop, confirm promotion is skipped (job logs show "N other release PR(s) still open, skipping promotion for now")
- [ ] Merge the remaining release PR, confirm promotion now fires and succeeds