### PR TITLE
docs: add Changelog header, fix platform_interface entry order

### DIFF
--- a/flutter_secure_storage_darwin/CHANGELOG.md
+++ b/flutter_secure_storage_darwin/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## 0.4.1
 - Fixed items written by versions prior to 0.3.0 becoming unreadable (and subsequent writes failing with `errSecDuplicateItem`) when no `accessControlFlags` are set. The 0.3.0 fix for `kSecAttrSynchronizable` being dropped caused `read`, `readAll` and `containsKey` to stop querying the legacy `kSecAttrAccessControl` storage envelope that those items were written under; they now fall back to it automatically. ([#1158](https://github.com/juliansteenbakker/flutter_secure_storage/issues/1158))
 

--- a/flutter_secure_storage_platform_interface/CHANGELOG.md
+++ b/flutter_secure_storage_platform_interface/CHANGELOG.md
@@ -1,5 +1,4 @@
-## 2.0.2
-Remove redundant `./` prefix from part directives.
+# Changelog
 
 ## [2.0.3](https://github.com/juliansteenbakker/flutter_secure_storage/compare/flutter_secure_storage_platform_interface-v2.0.2...flutter_secure_storage_platform_interface-v2.0.3) (2026-08-05)
 
@@ -7,6 +6,9 @@ Remove redundant `./` prefix from part directives.
 ### Bug Fixes
 
 * remove redundant ./ prefix from part directives ([cc7018d](https://github.com/juliansteenbakker/flutter_secure_storage/commit/cc7018d15eae56b389348d73f788ae1a03c606c6))
+
+## 2.0.2
+Remove redundant `./` prefix from part directives.
 
 ## 2.0.1
 Remove dart:io to support WASM build of web.

--- a/flutter_secure_storage_web/CHANGELOG.md
+++ b/flutter_secure_storage_web/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## 2.1.1
 - Fix potential key skipping in `readAll` when storage is modified concurrently during async decryption by collecting keys synchronously before awaiting.
 

--- a/flutter_secure_storage_windows/CHANGELOG.md
+++ b/flutter_secure_storage_windows/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## 4.2.2
 Fixed `deleteAll` and `containsKey` not acquiring the mutex lock, which could cause data races under concurrent access.
 


### PR DESCRIPTION
## Summary
- All six packages' `CHANGELOG.md` start directly with a version heading, with no top-level `# Changelog` title. Release-please appears to use that title as its insertion anchor; without it, new entries land after the existing top entry instead of before it (confirmed on the published `flutter_secure_storage_platform_interface` 2.0.3 changelog, and reproduced in the still-open #1206).
- Adds `# Changelog` to `flutter_secure_storage_darwin`, `flutter_secure_storage_web`, `flutter_secure_storage_windows`, and `flutter_secure_storage_platform_interface`.
- Reorders platform_interface's already-published 2.0.3/2.0.2 entries so 2.0.3 (newest) is listed first. Note: this doesn't change what's already displayed for the published 2.0.3 version on pub.dev (immutable), but corrects the source of truth for future releases.
- `flutter_secure_storage` and `flutter_secure_storage_linux` are handled separately in their own open release PRs (#1198, #1206) since editing them here would conflict.

## Test plan
- [ ] Next release for each of these four packages lands correctly ordered (newest entry first, above the previous release)