### PR TITLE
docs: add Changelog header to linux and main package

### DIFF
--- a/flutter_secure_storage/CHANGELOG.md
+++ b/flutter_secure_storage/CHANGELOG.md
@@ -1,8 +1,4 @@
-## Unreleased
-
-### Android
-
-- Fixed a fatal app crash when Android Keystore framework code throws `java.lang.Error` subclasses (e.g. `NoSuchFieldError` on some OEM builds with mismatched framework/KeyMint classes): the plugin's worker thread now catches `Throwable` and reports a `PlatformException` to Dart instead of killing the process.
+# Changelog
 
 ## 11.0.0-beta.1
 

--- a/flutter_secure_storage_linux/CHANGELOG.md
+++ b/flutter_secure_storage_linux/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## 3.0.1
 - Fixed `deleteKeyring` storing the string `"null"` instead of an empty JSON object `{}`.
 - Fixed non-UTF-8 error messages from libsecret causing a `FormatException` on the Dart side; messages are now sanitised before being sent through the method channel.


### PR DESCRIPTION
## Summary
- Follow-up to #1220. That PR fixed darwin/web/windows/platform_interface directly on develop, so it stuck. The equivalent manual fixes pushed onto #1206 and #1198's own branches did not: release-please force-pushes those branches on every subsequent push to develop, silently discarding manual edits (confirmed — both fix commits were wiped after later merges).
- Adds `# Changelog` to `flutter_secure_storage_linux` and `flutter_secure_storage` here on develop instead, so release-please has the anchor by the time it next regenerates #1206/#1198, and (hopefully) orders the next entries correctly without needing another manual fix.
- Also drops the stale hand-written `## Unreleased` section from the main package's changelog (added against CONTRIBUTING.md's guidance not to hand-edit it) — its content is already captured independently by release-please from commit history.

## Test plan
- [ ] After merging, confirm release-please regenerates #1206/#1198 with the new version entry correctly ordered above the previous release