### PR TITLE
fix(android): use flutter.compileSdkVersion instead of pinning `compileSdk`

### DIFF
--- a/flutter_secure_storage/android/build.gradle
+++ b/flutter_secure_storage/android/build.gradle
@@ -19,7 +19,7 @@ android {
         buildConfig = true
     }
 
-    compileSdk = 37
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
compileSdk 37 became the minimum every consuming app had to compile against, so apps on the current stable Flutter template (compileSdk 36, AGP 9.1, whose maximum recommended compileSdk is 36) failed in :app:checkAarMetadata and could not fix it without leaving the template defaults.

flutter.compileSdkVersion is the value the Flutter app template itself assigns to compileSdk, so plugin and app now derive from the same Flutter-managed default and move together on a Flutter upgrade. It is also what the first-party plugins do (image_picker, path_provider, shared_preferences, file_selector) and what the plus packages migrated to.

Verified with Flutter 3.47.0: an app on compileSdk 36 builds again (plugin resolves to 36), the example app on compileSdk 37 keeps building (plugin 36, which is fine — only compiling *above* the app is a problem), 151 Android unit tests pass, and the 12 Android integration tests pass on an API 36 emulator.

Refs: https://docs.flutter.dev/to/review-gradle-config

Fixes #1224

## Description

<!-- What does this PR change, and why? -->

## Checklist

- [x] The PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat: ...`, `fix: ...`, `chore: ...`). This is required by CI.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (`README.md`) was updated, if applicable.
- [ ] Affected package(s) had their version bumped in `pubspec.yaml` and a changelog entry added to `CHANGELOG.md`.
