### PR TITLE
fix(darwin): skip synchronizable keychain queries when the data protection keychain is off

### DIFF
--- a/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin/Sources/flutter_secure_storage_darwin/FlutterSecureStorage.swift
+++ b/flutter_secure_storage_darwin/darwin/flutter_secure_storage_darwin/Sources/flutter_secure_storage_darwin/FlutterSecureStorage.swift
@@ -380,12 +380,15 @@ class FlutterSecureStorage {
             return SecItemCopyMatching(query as CFDictionary, nil)
         }
 
-        // Check synchronizable items first.
-        let statusSync = queryKeychain(withSynchronizable: true)
-        if statusSync == errSecSuccess {
-            return .success(true)
-        } else if statusSync != errSecItemNotFound {
-            return .failure(OSSecError(status: statusSync))
+        // Check synchronizable items first, unless the data protection keychain
+        // is off: see performDelete for why that query cannot run there.
+        if !skipSynchronizableQueries(params) {
+            let statusSync = queryKeychain(withSynchronizable: true)
+            if statusSync == errSecSuccess {
+                return .success(true)
+            } else if statusSync != errSecItemNotFound {
+                return .failure(OSSecError(status: statusSync))
+            }
         }
 
         // Check non-synchronizable items.
@@ -685,6 +688,16 @@ class FlutterSecureStorage {
         return result
     }
 
+    /// True when a `kSecAttrSynchronizable = true` query would be rejected for
+    /// want of an entitlement: macOS, data protection keychain disabled.
+    private func skipSynchronizableQueries(_ params: KeychainQueryParameters) -> Bool {
+        #if os(macOS)
+        return !params.usesDataProtectionKeychain
+        #else
+        return false
+        #endif
+    }
+
     /// Private helper method to perform keychain deletion.
     /// Attempts to delete items with both synchronizable states and without accessibility constraints
     /// to ensure complete removal regardless of how items were originally stored.
@@ -709,7 +722,13 @@ class FlutterSecureStorage {
             return SecItemDelete(query as CFDictionary)
         }
 
-        let statusSync = deleteFromKeychain(withSynchronizable: true)
+        // Without the data protection keychain there is no synchronizable item to
+        // delete, and the query needs an entitlement an ad-hoc signed app cannot
+        // carry: it fails with errSecMissingEntitlement (-34018) and takes the
+        // whole delete with it. See juliansteenbakker/flutter_secure_storage#1104.
+        let statusSync = skipSynchronizableQueries(params)
+            ? errSecItemNotFound
+            : deleteFromKeychain(withSynchronizable: true)
         let statusNonSync = deleteFromKeychain(withSynchronizable: false)
 
         // Return success if both operations report item not found


### PR DESCRIPTION
Fixes #1104.

On macOS, an ad-hoc signed app with no `keychain-access-groups` entitlement and `MacOsOptions(usesDataProtectionKeychain: false)` gets `errSecMissingEntitlement` (-34018) from any keychain query carrying `kSecAttrSynchronizable = true`. Two paths in `FlutterSecureStorage.swift` issue that query unconditionally: `performDelete` runs the synchronizable pass before the non-synchronizable one, and `containsKey` runs its synchronizable check first and treats any status other than `errSecSuccess`/`errSecItemNotFound` as failure. `write` calls `containsKey(...).getOrElse(false)`, which swallows the error, so writes look fine while deletes and existence checks fail. Setting `synchronizable: false` in options doesn't help, since `performDelete` overwrites `isSynchronizable` itself regardless of the caller's value.

This adds a private `skipSynchronizableQueries(_:)` helper, true on macOS when `!usesDataProtectionKeychain`, false everywhere else. `performDelete` substitutes `errSecItemNotFound` for the synchronizable pass in that case instead of running the query; `containsKey` skips its synchronizable check the same way. Reasoning: without the data protection keychain there's no synchronizable item to find, so the query has nothing to do even when it's permitted to run. This isn't a behaviour change, it removes a query that could never succeed. Non-macOS platforms aren't touched.

Full disclosure: I don't have Apple hardware, so I haven't built or run this myself. The root cause matches the one described in #1104, and a user of my own app reproduced it and confirmed an equivalent patch resolves login persistence on an ad-hoc signed, sandboxed build with no `keychain-access-groups`.

If you'd rather handle this in `baseQuery` instead of at each call site, happy to rework it.