### PR TITLE
feat: add checkUpgradeStatus() to check for exisiting data after a missing or failed v10 migration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -36,3 +36,5 @@ ignore:
   - "flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherImplementationRSAOAEP.java"
   # StorageCipherImplementationAES23 requires an initialized biometric Cipher, covered by integration tests
   - "flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherImplementationAES23.java"
+  # UpgradeInspector's decrypt/keystore probes require AndroidKeyStore, covered by the upgrade matrix on a device
+  - "flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/UpgradeInspector.java"

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -163,6 +163,13 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                     options = new HashMap<>();
                 }
                 FlutterSecureStorageConfig config = new FlutterSecureStorageConfig(options);
+
+                if ("checkUpgradeStatus".equals(call.method)) {
+                    // Runs before initialize(), which is what would migrate or wipe.
+                    result.success(UpgradeInspector.inspect(applicationContext, config));
+                    return;
+                }
+
                 FlutterSecureStorage secureStorage = getOrCreateStorage(config);
 
                 secureStorage.initialize(config, new SecurePreferencesCallback<>() {

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/UpgradeInspector.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/UpgradeInspector.java
@@ -1,0 +1,222 @@
+package com.it_nomads.fluttersecurestorage;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.util.Base64;
+import android.util.Log;
+
+import java.security.KeyStore;
+
+import com.it_nomads.fluttersecurestorage.ciphers.KeyCipherAlgorithm;
+import com.it_nomads.fluttersecurestorage.ciphers.StorageCipher;
+import com.it_nomads.fluttersecurestorage.ciphers.StorageCipherAlgorithm;
+import com.it_nomads.fluttersecurestorage.ciphers.StorageCipherFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Reports whether data written by an older plugin version is still readable, so
+ * an app can warn its users before the next access discards it. Read-only: it
+ * checks that key material exists before building any cipher, since the cipher
+ * constructors create keys when they find none.
+ */
+public final class UpgradeInspector {
+
+    private static final String TAG = "UpgradeInspector";
+
+    // Mirrors SecureStorageUpgradeState on the Dart side.
+    static final String STATE_OK = "ok";
+    static final String STATE_LEGACY_DATA_UNREADABLE = "legacyDataUnreadable";
+    static final String STATE_LEGACY_DATA_DISCARDED = "legacyDataDiscarded";
+    static final String STATE_UNKNOWN = "unknown";
+
+    // Mirrors SecureStorageUpgradeReason on the Dart side.
+    static final String REASON_NONE = "none";
+    static final String REASON_REMOVED_CIPHER = "removedCipher";
+    static final String REASON_MISSING_ALGORITHM_MARKERS = "missingAlgorithmMarkers";
+    static final String REASON_LEGACY_BACKEND_PRESENT = "legacyBackendPresent";
+    static final String REASON_MISSING_KEY_MATERIAL = "missingKeyMaterial";
+    static final String REASON_DECRYPT_FAILED = "decryptFailed";
+    static final String REASON_AUTHENTICATION_REQUIRED = "authenticationRequired";
+
+    // Keys the Jetpack Security EncryptedSharedPreferences (Tink) backend
+    // writes into the data prefs file. v11 removed that backend.
+    private static final String TINK_KEY_KEYSET =
+            "__androidx_security_crypto_encrypted_prefs_key_keyset__";
+    private static final String TINK_VALUE_KEYSET =
+            "__androidx_security_crypto_encrypted_prefs_value_keyset__";
+    private static final String ALGORITHM_MARKER_PREFIX = "FlutterSecureSAlgorithm";
+    // The prefs key StorageCipherImplementationGCM stores the wrapped AES key under.
+    private static final String GCM_WRAPPED_KEY = "AESVGhpcyBpcyB0aGUga2V5IGZvciBhIHNlY3VyZSBzdG9yYWdlIEFFUyBLZXkK";
+
+    // Records a past wipe. Kept in the config prefs, which the delete paths
+    // don't clear, so it outlives the data it describes.
+    static final String DISCARDED_MARKER_KEY = "FlutterSecureStorageLegacyDataDiscarded";
+
+    private static final String BACKUP_SUFFIX = "_BACKUP";
+
+    private UpgradeInspector() {}
+
+    /**
+     * Inspects stored data and returns a status map for the method channel. A
+     * pending "data was discarded" report wins and is cleared as it's read, so
+     * an app sees it once.
+     */
+    public static Map<String, Object> inspect(Context context, FlutterSecureStorageConfig config) {
+        NamespacedConfigSource configSource =
+                new NamespacedConfigSource(context, config.getEffectiveDataPrefsName());
+
+        String discardedReason = configSource.getString(DISCARDED_MARKER_KEY, null);
+        if (discardedReason != null) {
+            configSource.edit().remove(DISCARDED_MARKER_KEY).apply();
+            return status(STATE_LEGACY_DATA_DISCARDED, discardedReason, 0, false,
+                    "Unreadable data was deleted by an earlier storage access.");
+        }
+
+        SharedPreferences dataPrefs = context.getSharedPreferences(
+                config.getEffectiveDataPrefsName(),
+                Context.MODE_PRIVATE
+        );
+
+        String keyPrefix = config.getSharedPreferencesKeyPrefix();
+        int entryCount = 0;
+        String sampleValue = null;
+        for (Map.Entry<String, ?> entry : dataPrefs.getAll().entrySet()) {
+            String key = entry.getKey();
+            if (!(entry.getValue() instanceof String) || !key.contains(keyPrefix) || key.endsWith(BACKUP_SUFFIX)) {
+                continue;
+            }
+            entryCount++;
+            if (sampleValue == null) {
+                sampleValue = (String) entry.getValue();
+            }
+        }
+
+        if (entryCount == 0) {
+            int tinkEntries = countEncryptedSharedPreferencesEntries(dataPrefs);
+            if (tinkEntries > 0) {
+                // v11 can't read the Tink store, but it also doesn't delete it,
+                // so a downgrade to v10 can still migrate the data.
+                return status(STATE_LEGACY_DATA_UNREADABLE, REASON_LEGACY_BACKEND_PRESENT,
+                        tinkEntries, false,
+                        "Data is in the EncryptedSharedPreferences (Tink) store, whose backend "
+                                + "v11 removed. Upgrading to v10 before v11 would have migrated it.");
+            }
+            return status(STATE_OK, REASON_NONE, 0, false, "No stored data.");
+        }
+
+        String savedKeyAlgorithm = StorageCipherFactory.readSavedKeyAlgorithm(configSource);
+        String savedStorageAlgorithm = StorageCipherFactory.readSavedStorageAlgorithm(configSource);
+
+        if (savedKeyAlgorithm == null || savedStorageAlgorithm == null) {
+            return unreadable(config, REASON_MISSING_ALGORITHM_MARKERS, entryCount,
+                    "Data carries no algorithm markers, so it was written by v9 or earlier. "
+                            + "Upgrading to v10 before v11 would have migrated it.");
+        }
+
+        if (KeyCipherAlgorithm.isRemoved(savedKeyAlgorithm)
+                || StorageCipherAlgorithm.isRemoved(savedStorageAlgorithm)) {
+            return unreadable(config, REASON_REMOVED_CIPHER, entryCount,
+                    "Data was encrypted with " + savedKeyAlgorithm + "/" + savedStorageAlgorithm
+                            + ", removed in v11. Upgrading to v10 before v11 would have migrated it.");
+        }
+
+        KeyCipherAlgorithm keyAlgorithm;
+        try {
+            keyAlgorithm = KeyCipherAlgorithm.fromString(savedKeyAlgorithm);
+            StorageCipherAlgorithm.fromString(savedStorageAlgorithm);
+        } catch (IllegalArgumentException e) {
+            return unreadable(config, REASON_REMOVED_CIPHER, entryCount,
+                    "Data was encrypted with unrecognised algorithm markers "
+                            + savedKeyAlgorithm + "/" + savedStorageAlgorithm + ".");
+        }
+
+        if (keyAlgorithm == KeyCipherAlgorithm.AES_GCM_NoPadding) {
+            // Decrypting would trigger a biometric prompt, which a preflight must not.
+            return status(STATE_UNKNOWN, REASON_AUTHENTICATION_REQUIRED, entryCount, false,
+                    "Stored data is behind user authentication, so it was not read.");
+        }
+
+        SharedPreferences keyPrefs = context.getSharedPreferences(
+                config.getEffectiveKeyStoragePrefsName(),
+                Context.MODE_PRIVATE
+        );
+
+        if (!hasRsaKeyStoreEntry(context, config)
+                || keyPrefs.getString(GCM_WRAPPED_KEY, null) == null) {
+            return unreadable(config, REASON_MISSING_KEY_MATERIAL, entryCount,
+                    "Stored data is orphaned: the key needed to decrypt it is gone.");
+        }
+
+        try {
+            // Pass the saved algorithms as the current ones so the factory
+            // doesn't see an algorithm change and doesn't write anything.
+            StorageCipherFactory factory = new StorageCipherFactory(
+                    configSource, savedKeyAlgorithm, savedStorageAlgorithm, config);
+            StorageCipher cipher = factory.getSavedStorageCipher(context, null);
+            cipher.decrypt(Base64.decode(sampleValue, 0));
+            return status(STATE_OK, REASON_NONE, entryCount, false, "Stored data is readable.");
+        } catch (Throwable e) {
+            if (e instanceof VirtualMachineError) {
+                throw (VirtualMachineError) e;
+            }
+            Log.w(TAG, "Trial decryption of stored data failed", e);
+            return unreadable(config, REASON_DECRYPT_FAILED, entryCount,
+                    "Stored data could not be decrypted: " + e.getMessage());
+        }
+    }
+
+    // Counts real entries in a Tink data file (not the keysets or our markers).
+    // Returns 0 if the file isn't a Tink store.
+    private static int countEncryptedSharedPreferencesEntries(SharedPreferences dataPrefs) {
+        Map<String, ?> all = dataPrefs.getAll();
+        if (!all.containsKey(TINK_KEY_KEYSET) && !all.containsKey(TINK_VALUE_KEYSET)) {
+            return 0;
+        }
+        int count = 0;
+        for (Map.Entry<String, ?> entry : all.entrySet()) {
+            String key = entry.getKey();
+            if (!(entry.getValue() instanceof String)
+                    || key.equals(TINK_KEY_KEYSET)
+                    || key.equals(TINK_VALUE_KEYSET)
+                    || key.startsWith(ALGORITHM_MARKER_PREFIX)
+                    || key.equals(DISCARDED_MARKER_KEY)) {
+                continue;
+            }
+            count++;
+        }
+        return count;
+    }
+
+    // Whether the RSA-OAEP key that decrypts non-biometric data is still in
+    // the KeyStore. Read-only; never generates one.
+    private static boolean hasRsaKeyStoreEntry(Context context, FlutterSecureStorageConfig config) {
+        String alias = context.getPackageName()
+                + ".FlutterSecureStoragePluginKeyOAEP" + config.getKeyAliasSuffix();
+        try {
+            KeyStore ks = KeyStore.getInstance("AndroidKeyStore");
+            ks.load(null);
+            return ks.containsAlias(alias);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static Map<String, Object> unreadable(FlutterSecureStorageConfig config,
+                                                  String reason, int entryCount, String details) {
+        return status(STATE_LEGACY_DATA_UNREADABLE, reason, entryCount,
+                config.shouldDeleteOnFailure(), details);
+    }
+
+    private static Map<String, Object> status(String state, String reason, int entryCount,
+                                              boolean willDiscardOnNextAccess, String details) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("state", state);
+        result.put("reason", reason);
+        result.put("entryCount", entryCount);
+        result.put("willDiscardOnNextAccess", willDiscardOnNextAccess);
+        result.put("details", details);
+        return result;
+    }
+}

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherAlgorithm.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipherAlgorithm.java
@@ -25,4 +25,9 @@ public enum KeyCipherAlgorithm {
         }
         return valueOf(name);
     }
+
+    /** True for a marker whose cipher v11 removed; that data can't be read. */
+    public static boolean isRemoved(String name) {
+        return "RSA_ECB_PKCS1Padding".equals(name);
+    }
 }

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherAlgorithm.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherAlgorithm.java
@@ -25,4 +25,9 @@ public enum StorageCipherAlgorithm {
         }
         return valueOf(name);
     }
+
+    /** True for a marker whose cipher v11 removed; that data can't be read. */
+    public static boolean isRemoved(String name) {
+        return "AES_CBC_PKCS7Padding".equals(name);
+    }
 }

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherFactory.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherFactory.java
@@ -113,6 +113,16 @@ public class StorageCipherFactory {
         return savedKeyAlgorithm.keyCipher.apply(context, config);
     }
 
+    /** Reads the saved key-cipher marker, or null if none was ever written. */
+    public static String readSavedKeyAlgorithm(NamespacedConfigSource configSource) {
+        return configSource.getString(ELEMENT_PREFERENCES_ALGORITHM_KEY, null);
+    }
+
+    /** Reads the saved storage-cipher marker, or null if none was ever written. */
+    public static String readSavedStorageAlgorithm(NamespacedConfigSource configSource) {
+        return configSource.getString(ELEMENT_PREFERENCES_ALGORITHM_STORAGE, null);
+    }
+
     public void storeCurrentAlgorithms(SharedPreferences.Editor editor) {
         editor.putString(ELEMENT_PREFERENCES_ALGORITHM_KEY, currentKeyAlgorithm.name());
         editor.putString(ELEMENT_PREFERENCES_ALGORITHM_STORAGE, currentStorageAlgorithm.name());

--- a/flutter_secure_storage/android/src/test/java/com/it_nomads/fluttersecurestorage/UpgradeInspectorTest.java
+++ b/flutter_secure_storage/android/src/test/java/com/it_nomads/fluttersecurestorage/UpgradeInspectorTest.java
@@ -1,0 +1,263 @@
+package com.it_nomads.fluttersecurestorage;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 34)
+public class UpgradeInspectorTest {
+
+    private static final String PREFS_NAME = "UpgradeInspectorTestData";
+    private static final String KEY_PREFIX = "TestPrefix";
+    private static final String ALGORITHM_KEY_MARKER = "FlutterSecureSAlgorithmKey";
+    private static final String ALGORITHM_STORAGE_MARKER = "FlutterSecureSAlgorithmStorage";
+
+    private Context context;
+    private SharedPreferences dataPrefs;
+    private NamespacedConfigSource configSource;
+
+    @Before
+    public void setUp() {
+        context = RuntimeEnvironment.getApplication();
+        dataPrefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+        dataPrefs.edit().clear().commit();
+        configSource = new NamespacedConfigSource(context, PREFS_NAME);
+        configSource.edit().clear().commit();
+    }
+
+    private FlutterSecureStorageConfig config(boolean resetOnError) {
+        Map<String, Object> options = new HashMap<>();
+        options.put(FlutterSecureStorageConfig.PREF_OPTION_NAME, PREFS_NAME);
+        options.put(FlutterSecureStorageConfig.PREF_OPTION_PREFIX, KEY_PREFIX);
+        options.put(FlutterSecureStorageConfig.PREF_OPTION_DELETE_ON_FAILURE, String.valueOf(resetOnError));
+        return new FlutterSecureStorageConfig(options);
+    }
+
+    private void storeEntry(String key, String value) {
+        dataPrefs.edit().putString(KEY_PREFIX + "_" + key, value).commit();
+    }
+
+    private void storeMarkers(String keyAlgorithm, String storageAlgorithm) {
+        configSource.edit()
+                .putString(ALGORITHM_KEY_MARKER, keyAlgorithm)
+                .putString(ALGORITHM_STORAGE_MARKER, storageAlgorithm)
+                .commit();
+    }
+
+    private Map<String, Object> inspect(boolean resetOnError) {
+        return UpgradeInspector.inspect(context, config(resetOnError));
+    }
+
+    @Test
+    public void emptyStorageIsOk() {
+        Map<String, Object> status = inspect(true);
+
+        assertEquals(UpgradeInspector.STATE_OK, status.get("state"));
+        assertEquals(UpgradeInspector.REASON_NONE, status.get("reason"));
+        assertEquals(0, status.get("entryCount"));
+        assertFalse((Boolean) status.get("willDiscardOnNextAccess"));
+    }
+
+    @Test
+    public void dataWithoutAlgorithmMarkersIsUnreadable() {
+        storeEntry("token", "ciphertext");
+
+        Map<String, Object> status = inspect(true);
+
+        assertEquals(UpgradeInspector.STATE_LEGACY_DATA_UNREADABLE, status.get("state"));
+        assertEquals(UpgradeInspector.REASON_MISSING_ALGORITHM_MARKERS, status.get("reason"));
+        assertEquals(1, status.get("entryCount"));
+        assertTrue((Boolean) status.get("willDiscardOnNextAccess"));
+    }
+
+    @Test
+    public void encryptedSharedPreferencesStoreIsReportedAsUnreadable() {
+        dataPrefs.edit()
+                .putString("__androidx_security_crypto_encrypted_prefs_key_keyset__", "keyset")
+                .putString("__androidx_security_crypto_encrypted_prefs_value_keyset__", "keyset")
+                .putString("AencryptedKeyNameA", "AencryptedValueA")
+                .putString("AencryptedKeyNameB", "AencryptedValueB")
+                .commit();
+
+        Map<String, Object> status = inspect(true);
+
+        assertEquals(UpgradeInspector.STATE_LEGACY_DATA_UNREADABLE, status.get("state"));
+        assertEquals(UpgradeInspector.REASON_LEGACY_BACKEND_PRESENT, status.get("reason"));
+        assertEquals(2, status.get("entryCount"));
+        // v11 doesn't delete the Tink store, so a downgrade can still migrate it.
+        assertFalse((Boolean) status.get("willDiscardOnNextAccess"));
+    }
+
+    @Test
+    public void emptyEncryptedSharedPreferencesStoreIsOk() {
+        dataPrefs.edit()
+                .putString("__androidx_security_crypto_encrypted_prefs_key_keyset__", "keyset")
+                .putString("__androidx_security_crypto_encrypted_prefs_value_keyset__", "keyset")
+                .commit();
+
+        Map<String, Object> status = inspect(true);
+
+        assertEquals(UpgradeInspector.STATE_OK, status.get("state"));
+        assertEquals(0, status.get("entryCount"));
+    }
+
+    @Test
+    public void resetOnErrorDisabledMeansDataIsNotDiscarded() {
+        storeEntry("token", "ciphertext");
+
+        Map<String, Object> status = inspect(false);
+
+        assertEquals(UpgradeInspector.STATE_LEGACY_DATA_UNREADABLE, status.get("state"));
+        assertFalse((Boolean) status.get("willDiscardOnNextAccess"));
+    }
+
+    @Test
+    public void ciphersRemovedInV11AreReportedAsSuch() {
+        storeEntry("token", "ciphertext");
+        storeMarkers("RSA_ECB_PKCS1Padding", "AES_CBC_PKCS7Padding");
+
+        Map<String, Object> status = inspect(true);
+
+        assertEquals(UpgradeInspector.STATE_LEGACY_DATA_UNREADABLE, status.get("state"));
+        assertEquals(UpgradeInspector.REASON_REMOVED_CIPHER, status.get("reason"));
+        assertTrue(((String) status.get("details")).contains("RSA_ECB_PKCS1Padding"));
+    }
+
+    @Test
+    public void removedStorageCipherAloneIsEnough() {
+        storeEntry("token", "ciphertext");
+        storeMarkers("RSA_ECB_OAEPwithSHA_256andMGF1Padding", "AES_CBC_PKCS7Padding");
+
+        Map<String, Object> status = inspect(true);
+
+        assertEquals(UpgradeInspector.STATE_LEGACY_DATA_UNREADABLE, status.get("state"));
+        assertEquals(UpgradeInspector.REASON_REMOVED_CIPHER, status.get("reason"));
+    }
+
+    @Test
+    public void unrecognisedMarkersAreReportedRatherThanThrown() {
+        storeEntry("token", "ciphertext");
+        storeMarkers("SomethingElseEntirely", "AES_GCM_NoPadding");
+
+        Map<String, Object> status = inspect(true);
+
+        assertEquals(UpgradeInspector.STATE_LEGACY_DATA_UNREADABLE, status.get("state"));
+        assertEquals(UpgradeInspector.REASON_REMOVED_CIPHER, status.get("reason"));
+    }
+
+    @Test
+    public void authenticatedDataIsNotReadDuringAProbe() {
+        storeEntry("token", "ciphertext");
+        storeMarkers("AES_GCM_NoPadding", "AES_GCM_NoPadding");
+
+        Map<String, Object> status = inspect(true);
+
+        assertEquals(UpgradeInspector.STATE_UNKNOWN, status.get("state"));
+        assertEquals(UpgradeInspector.REASON_AUTHENTICATION_REQUIRED, status.get("reason"));
+        assertFalse((Boolean) status.get("willDiscardOnNextAccess"));
+    }
+
+    @Test
+    public void dataWithoutKeyMaterialIsOrphaned() {
+        storeEntry("token", "ciphertext");
+        storeMarkers("RSA_ECB_OAEPwithSHA_256andMGF1Padding", "AES_GCM_NoPadding");
+
+        Map<String, Object> status = inspect(true);
+
+        assertEquals(UpgradeInspector.STATE_LEGACY_DATA_UNREADABLE, status.get("state"));
+        assertEquals(UpgradeInspector.REASON_MISSING_KEY_MATERIAL, status.get("reason"));
+    }
+
+    @Test
+    public void discardedMarkerIsReportedOnceThenCleared() {
+        configSource.edit()
+                .putString(UpgradeInspector.DISCARDED_MARKER_KEY, UpgradeInspector.REASON_DECRYPT_FAILED)
+                .commit();
+
+        Map<String, Object> first = inspect(true);
+        assertEquals(UpgradeInspector.STATE_LEGACY_DATA_DISCARDED, first.get("state"));
+        assertEquals(UpgradeInspector.REASON_DECRYPT_FAILED, first.get("reason"));
+
+        Map<String, Object> second = inspect(true);
+        assertEquals(UpgradeInspector.STATE_OK, second.get("state"));
+        assertNull(configSource.getString(UpgradeInspector.DISCARDED_MARKER_KEY, null));
+    }
+
+    @Test
+    public void discardedMarkerTakesPrecedenceOverRemainingData() {
+        storeEntry("token", "ciphertext");
+        configSource.edit()
+                .putString(UpgradeInspector.DISCARDED_MARKER_KEY, UpgradeInspector.REASON_DECRYPT_FAILED)
+                .commit();
+
+        Map<String, Object> status = inspect(true);
+
+        assertEquals(UpgradeInspector.STATE_LEGACY_DATA_DISCARDED, status.get("state"));
+    }
+
+    @Test
+    public void backupEntriesAreNotCounted() {
+        dataPrefs.edit().putString(KEY_PREFIX + "_token_BACKUP", "ciphertext").commit();
+
+        Map<String, Object> status = inspect(true);
+
+        assertEquals(UpgradeInspector.STATE_OK, status.get("state"));
+        assertEquals(0, status.get("entryCount"));
+    }
+
+    @Test
+    public void entriesOutsideThePrefixAreNotCounted() {
+        dataPrefs.edit().putString("SomeOtherPluginKey", "value").commit();
+
+        Map<String, Object> status = inspect(true);
+
+        assertEquals(UpgradeInspector.STATE_OK, status.get("state"));
+        assertEquals(0, status.get("entryCount"));
+    }
+
+    @Test
+    public void allMatchingEntriesAreCounted() {
+        storeEntry("token", "a");
+        storeEntry("refresh", "b");
+        storeEntry("pin", "c");
+
+        Map<String, Object> status = inspect(true);
+
+        assertEquals(3, status.get("entryCount"));
+    }
+
+    @Test
+    public void inspectingDoesNotWriteAlgorithmMarkers() {
+        storeEntry("token", "ciphertext");
+
+        inspect(true);
+
+        assertNull(configSource.getString(ALGORITHM_KEY_MARKER, null));
+        assertNull(configSource.getString(ALGORITHM_STORAGE_MARKER, null));
+    }
+
+    @Test
+    public void inspectingDoesNotTouchStoredData() {
+        storeEntry("token", "ciphertext");
+        storeMarkers("RSA_ECB_PKCS1Padding", "AES_CBC_PKCS7Padding");
+
+        inspect(true);
+
+        assertEquals("ciphertext", dataPrefs.getString(KEY_PREFIX + "_token", null));
+    }
+}

--- a/flutter_secure_storage/lib/flutter_secure_storage.dart
+++ b/flutter_secure_storage/lib/flutter_secure_storage.dart
@@ -7,6 +7,12 @@ import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
 import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
 
+export 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart'
+    show
+        SecureStorageUpgradeReason,
+        SecureStorageUpgradeState,
+        SecureStorageUpgradeStatus;
+
 part 'options/android_options.dart';
 part 'options/apple_options.dart';
 part 'options/linux_options.dart';
@@ -388,6 +394,34 @@ class FlutterSecureStorage {
       ? await (_platform as MethodChannelFlutterSecureStorage)
             .isCupertinoProtectedDataAvailable()
       : null;
+
+  /// Reports whether data written by an older version of the plugin survived
+  /// the upgrade to this version.
+  ///
+  /// Read-only: it never writes, migrates, or deletes anything. Call it on
+  /// startup, before the first [read] or [write], to catch a direct major
+  /// upgrade that left data undecryptable and re-authenticate the user instead
+  /// of losing them silently.
+  ///
+  /// Android only; other platforms return
+  /// [SecureStorageUpgradeStatus.unsupported].
+  Future<SecureStorageUpgradeStatus> checkUpgradeStatus({
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) => _platform.checkUpgradeStatus(
+    options: _selectOptions(
+      iOptions,
+      aOptions,
+      lOptions,
+      webOptions,
+      mOptions,
+      wOptions,
+    ),
+  );
 
   /// Initializes the shared preferences with mock values for testing.
   @visibleForTesting

--- a/flutter_secure_storage/test/flutter_secure_storage_test.dart
+++ b/flutter_secure_storage/test/flutter_secure_storage_test.dart
@@ -1143,6 +1143,33 @@ void main() {
     );
   });
 
+  group('checkUpgradeStatus', () {
+    test('delegates to the platform with the selected options', () async {
+      const report = SecureStorageUpgradeStatus(
+        state: SecureStorageUpgradeState.legacyDataUnreadable,
+        reason: SecureStorageUpgradeReason.missingAlgorithmMarkers,
+        entryCount: 2,
+        willDiscardOnNextAccess: true,
+      );
+      when(
+        () => mockPlatform.checkUpgradeStatus(
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) async => report);
+
+      final result = await storage.checkUpgradeStatus(
+        aOptions: AndroidOptions.defaultOptions,
+      );
+
+      expect(result, report);
+      verify(
+        () => mockPlatform.checkUpgradeStatus(
+          options: any(named: 'options'),
+        ),
+      ).called(1);
+    });
+  });
+
   group('Test Helper Methods', () {
     test('setMockInitialValues sets up test platform with initial data', () {
       final testData = {'testKey': 'testValue', 'key2': 'value2'};

--- a/flutter_secure_storage_platform_interface/lib/flutter_secure_storage_platform_interface.dart
+++ b/flutter_secure_storage_platform_interface/lib/flutter_secure_storage_platform_interface.dart
@@ -6,6 +6,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 part 'src/method_channel_flutter_secure_storage.dart';
 part 'src/options.dart';
+part 'src/upgrade_status.dart';
 
 /// The interface that implementations of flutter_secure_storage must implement.
 ///
@@ -120,4 +121,17 @@ abstract class FlutterSecureStoragePlatform extends PlatformInterface {
   Future<void> deleteAll({
     required Map<String, String> options,
   });
+
+  /// Reports whether data written by an older version of the plugin survived
+  /// the upgrade to this version. Never writes, migrates, or deletes anything.
+  ///
+  /// Parameters:
+  /// - [options]: the same platform options passed to read and write.
+  ///
+  /// Returns [SecureStorageUpgradeStatus.unsupported] on platforms that do not
+  /// implement the check.
+  Future<SecureStorageUpgradeStatus> checkUpgradeStatus({
+    required Map<String, String> options,
+  }) async =>
+      SecureStorageUpgradeStatus.unsupported;
 }

--- a/flutter_secure_storage_platform_interface/lib/src/method_channel_flutter_secure_storage.dart
+++ b/flutter_secure_storage_platform_interface/lib/src/method_channel_flutter_secure_storage.dart
@@ -114,4 +114,22 @@ class MethodChannelFlutterSecureStorage extends FlutterSecureStoragePlatform {
         'value': value,
         'options': options,
       });
+
+  @override
+  Future<SecureStorageUpgradeStatus> checkUpgradeStatus({
+    required Map<String, String> options,
+  }) async {
+    try {
+      final result = await _channel.invokeMethod<Map<Object?, Object?>>(
+        'checkUpgradeStatus',
+        {'options': options},
+      );
+      if (result == null) {
+        return SecureStorageUpgradeStatus.unsupported;
+      }
+      return SecureStorageUpgradeStatus.fromMap(result);
+    } on MissingPluginException {
+      return SecureStorageUpgradeStatus.unsupported;
+    }
+  }
 }

--- a/flutter_secure_storage_platform_interface/lib/src/upgrade_status.dart
+++ b/flutter_secure_storage_platform_interface/lib/src/upgrade_status.dart
@@ -1,0 +1,150 @@
+part of '../flutter_secure_storage_platform_interface.dart';
+
+/// The overall result of [FlutterSecureStoragePlatform.checkUpgradeStatus].
+enum SecureStorageUpgradeState {
+  /// Nothing at risk: the storage is empty, verified readable, or the platform
+  /// has nothing to report.
+  ok,
+
+  /// Data is present that this plugin version cannot decrypt. Not touched yet;
+  /// see [SecureStorageUpgradeStatus.willDiscardOnNextAccess].
+  legacyDataUnreadable,
+
+  /// Unreadable data was already deleted by an earlier access. Reported once,
+  /// then cleared.
+  legacyDataDiscarded,
+
+  /// The state could not be checked without side effects, usually a biometric
+  /// prompt.
+  unknown,
+}
+
+/// Explains why storage is in the reported [SecureStorageUpgradeState].
+enum SecureStorageUpgradeReason {
+  /// No further detail.
+  none,
+
+  /// Encrypted with a cipher that v11 removed.
+  removedCipher,
+
+  /// No algorithm markers, so it was written by v9 or earlier.
+  missingAlgorithmMarkers,
+
+  /// Still in the EncryptedSharedPreferences (Jetpack Security / Tink) store,
+  /// whose backend v11 removed.
+  legacyBackendPresent,
+
+  /// The key needed to decrypt the data is gone.
+  missingKeyMaterial,
+
+  /// Decrypting a stored entry was tried and failed.
+  decryptFailed,
+
+  /// Reading needs user authentication, so nothing was tried.
+  authenticationRequired,
+
+  /// The platform does not implement this check.
+  unsupportedPlatform,
+}
+
+/// A read-only report from [FlutterSecureStoragePlatform.checkUpgradeStatus]
+/// on whether stored data survived a plugin upgrade. Producing it never writes,
+/// migrates, or deletes anything.
+@immutable
+class SecureStorageUpgradeStatus {
+  /// Creates an upgrade status report.
+  const SecureStorageUpgradeStatus({
+    required this.state,
+    this.reason = SecureStorageUpgradeReason.none,
+    this.entryCount = 0,
+    this.willDiscardOnNextAccess = false,
+    this.details,
+  });
+
+  /// Builds a status from the map sent over the method channel. Unrecognised
+  /// names decay to [SecureStorageUpgradeState.unknown] /
+  /// [SecureStorageUpgradeReason.none] so a newer native side can't crash an
+  /// older Dart side.
+  factory SecureStorageUpgradeStatus.fromMap(Map<Object?, Object?> map) =>
+      SecureStorageUpgradeStatus(
+        state: _enumByName(
+          SecureStorageUpgradeState.values,
+          map['state'],
+          SecureStorageUpgradeState.unknown,
+        ),
+        reason: _enumByName(
+          SecureStorageUpgradeReason.values,
+          map['reason'],
+          SecureStorageUpgradeReason.none,
+        ),
+        entryCount: map['entryCount'] is int ? map['entryCount']! as int : 0,
+        willDiscardOnNextAccess: map['willDiscardOnNextAccess'] == true,
+        details: map['details'] as String?,
+      );
+
+  /// The status returned on platforms that do not implement the check.
+  static const unsupported = SecureStorageUpgradeStatus(
+    state: SecureStorageUpgradeState.ok,
+    reason: SecureStorageUpgradeReason.unsupportedPlatform,
+  );
+
+  /// What, if anything, is wrong.
+  final SecureStorageUpgradeState state;
+
+  /// Why storage is in this [state].
+  final SecureStorageUpgradeReason reason;
+
+  /// How many stored entries the report covers. For
+  /// [SecureStorageUpgradeState.legacyDataUnreadable], how many would be lost.
+  final int entryCount;
+
+  /// Whether the next read or write will delete the unreadable data. True when
+  /// [state] is [SecureStorageUpgradeState.legacyDataUnreadable] and
+  /// `resetOnError` is enabled (the default); when false the data stays on disk
+  /// and the next access fails.
+  final bool willDiscardOnNextAccess;
+
+  /// A human-readable explanation for a log line, if the platform gave one. Not
+  /// for end users.
+  final String? details;
+
+  /// Whether data is or was lost, so the app should re-authenticate the user
+  /// or re-fetch what it had cached.
+  bool get hasDataLoss =>
+      state == SecureStorageUpgradeState.legacyDataUnreadable ||
+      state == SecureStorageUpgradeState.legacyDataDiscarded;
+
+  @override
+  String toString() => 'SecureStorageUpgradeStatus(state: ${state.name}, '
+      'reason: ${reason.name}, entryCount: $entryCount, '
+      'willDiscardOnNextAccess: $willDiscardOnNextAccess, '
+      'details: $details)';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SecureStorageUpgradeStatus &&
+          other.state == state &&
+          other.reason == reason &&
+          other.entryCount == entryCount &&
+          other.willDiscardOnNextAccess == willDiscardOnNextAccess &&
+          other.details == details;
+
+  @override
+  int get hashCode => Object.hash(
+        state,
+        reason,
+        entryCount,
+        willDiscardOnNextAccess,
+        details,
+      );
+}
+
+T _enumByName<T extends Enum>(List<T> values, Object? name, T fallback) {
+  for (final value in values) {
+    if (value.name == name) {
+      return value;
+    }
+  }
+  return fallback;
+}

--- a/flutter_secure_storage_platform_interface/test/upgrade_status_test.dart
+++ b/flutter_secure_storage_platform_interface/test/upgrade_status_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SecureStorageUpgradeStatus.fromMap', () {
+    test('parses a full report', () {
+      final status = SecureStorageUpgradeStatus.fromMap(const {
+        'state': 'legacyDataUnreadable',
+        'reason': 'removedCipher',
+        'entryCount': 3,
+        'willDiscardOnNextAccess': true,
+        'details': 'RSA_ECB_PKCS1Padding was removed in v11.',
+      });
+
+      expect(status.state, SecureStorageUpgradeState.legacyDataUnreadable);
+      expect(status.reason, SecureStorageUpgradeReason.removedCipher);
+      expect(status.entryCount, 3);
+      expect(status.willDiscardOnNextAccess, true);
+      expect(status.details, 'RSA_ECB_PKCS1Padding was removed in v11.');
+      expect(status.hasDataLoss, true);
+    });
+
+    test('falls back on names a newer native side might send', () {
+      final status = SecureStorageUpgradeStatus.fromMap(const {
+        'state': 'somethingAddedLater',
+        'reason': 'alsoAddedLater',
+      });
+
+      expect(status.state, SecureStorageUpgradeState.unknown);
+      expect(status.reason, SecureStorageUpgradeReason.none);
+      expect(status.entryCount, 0);
+      expect(status.willDiscardOnNextAccess, false);
+      expect(status.details, isNull);
+    });
+
+    test('parses the legacyBackendPresent reason', () {
+      final status = SecureStorageUpgradeStatus.fromMap(const {
+        'state': 'legacyDataUnreadable',
+        'reason': 'legacyBackendPresent',
+        'entryCount': 4,
+        'willDiscardOnNextAccess': false,
+      });
+
+      expect(status.reason, SecureStorageUpgradeReason.legacyBackendPresent);
+      expect(status.hasDataLoss, true);
+      expect(status.willDiscardOnNextAccess, false);
+    });
+
+    test('hasDataLoss covers data that was already discarded', () {
+      final status = SecureStorageUpgradeStatus.fromMap(const {
+        'state': 'legacyDataDiscarded',
+        'reason': 'decryptFailed',
+      });
+
+      expect(status.hasDataLoss, true);
+      expect(status.willDiscardOnNextAccess, false);
+    });
+
+    test('ok reports no data loss', () {
+      final status = SecureStorageUpgradeStatus.fromMap(const {
+        'state': 'ok',
+        'reason': 'none',
+        'entryCount': 5,
+      });
+
+      expect(status.hasDataLoss, false);
+      expect(status.entryCount, 5);
+    });
+  });
+
+  group('SecureStorageUpgradeStatus value semantics', () {
+    const a = SecureStorageUpgradeStatus(
+      state: SecureStorageUpgradeState.legacyDataUnreadable,
+      reason: SecureStorageUpgradeReason.removedCipher,
+      entryCount: 2,
+      willDiscardOnNextAccess: true,
+      details: 'x',
+    );
+
+    test('equal values compare equal and share a hashCode', () {
+      const b = SecureStorageUpgradeStatus(
+        state: SecureStorageUpgradeState.legacyDataUnreadable,
+        reason: SecureStorageUpgradeReason.removedCipher,
+        entryCount: 2,
+        willDiscardOnNextAccess: true,
+        details: 'x',
+      );
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, a); // identical fast path
+    });
+
+    test('different values are not equal', () {
+      expect(a == SecureStorageUpgradeStatus.unsupported, isFalse);
+      expect(a == const Object(), isFalse);
+    });
+
+    test('toString names the fields', () {
+      expect(
+        a.toString(),
+        'SecureStorageUpgradeStatus(state: legacyDataUnreadable, '
+        'reason: removedCipher, entryCount: 2, '
+        'willDiscardOnNextAccess: true, details: x)',
+      );
+    });
+  });
+
+  group('MethodChannelFlutterSecureStorage.checkUpgradeStatus', () {
+    const channel = MethodChannel(
+      'plugins.it_nomads.com/flutter_secure_storage',
+    );
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    final storage = MethodChannelFlutterSecureStorage();
+    const options = <String, String>{'resetOnError': 'true'};
+
+    tearDown(() => messenger.setMockMethodCallHandler(channel, null));
+
+    test('forwards options and parses the reply', () async {
+      final log = <MethodCall>[];
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        log.add(call);
+        return <Object?, Object?>{
+          'state': 'legacyDataUnreadable',
+          'reason': 'missingAlgorithmMarkers',
+          'entryCount': 2,
+          'willDiscardOnNextAccess': true,
+          'details': 'No algorithm markers found.',
+        };
+      });
+
+      final status = await storage.checkUpgradeStatus(options: options);
+
+      expect(log, [
+        isMethodCall('checkUpgradeStatus', arguments: {'options': options}),
+      ]);
+      expect(status.state, SecureStorageUpgradeState.legacyDataUnreadable);
+      expect(status.reason, SecureStorageUpgradeReason.missingAlgorithmMarkers);
+      expect(status.entryCount, 2);
+      expect(status.willDiscardOnNextAccess, true);
+    });
+
+    test('reports unsupported when the platform has no handler', () async {
+      // No mock handler registered, so the channel raises
+      // MissingPluginException, exactly as a native side predating this
+      // method would.
+      final status = await storage.checkUpgradeStatus(options: options);
+
+      expect(status, SecureStorageUpgradeStatus.unsupported);
+      expect(status.state, SecureStorageUpgradeState.ok);
+      expect(status.reason, SecureStorageUpgradeReason.unsupportedPlatform);
+      expect(status.hasDataLoss, false);
+    });
+
+    test('reports unsupported when the platform replies with null', () async {
+      messenger.setMockMethodCallHandler(channel, (call) async => null);
+
+      final status = await storage.checkUpgradeStatus(options: options);
+
+      expect(status, SecureStorageUpgradeStatus.unsupported);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds `checkUpgradeStatus()`, a read-only check that apps can run on startup before accessing secure storage.

Its purpose is to detect whether existing Android data can still be read after upgrading the plugin. If the old data is no longer readable, it returns the reason, such as:

* missing algorithm information
* data encrypted with a cipher that was removed in v11
* data still stored using EncryptedSharedPreferences/Tink
* missing key material

It also returns the number of stored entries and whether the data would be discarded on the next access.

This gives apps a chance to re-authenticate the user or re-sync their data instead of discovering the problem only after the data has been lost.

`checkUpgradeStatus()` does not write, migrate, or delete anything. It is android only. Other platforms return `unsupported`.

Changes:

* `flutter_secure_storage`

  * Adds `FlutterSecureStorage.checkUpgradeStatus({...options})`
  * Re-exports `SecureStorageUpgradeStatus`, `SecureStorageUpgradeState`, and `SecureStorageUpgradeReason`

* `flutter_secure_storage_platform_interface`

  * Adds `checkUpgradeStatus` to `FlutterSecureStoragePlatform`
  * The default implementation returns `unsupported`, so this is non-breaking for existing implementations that extend the platform interface

Together with the already released 10.3.2, this addresses the reported v9/v10 to v11 data-loss issues.

Version 10.3.2 fixed the Android issues directly (#1079, #1126, #1166, #1212, #1064, #1084) and also made rolling back from v11 to a 10.3.x release non-destructive.

This PR covers the cases that v11 cannot read, mainly data encrypted with removed ciphers or data that is still in the old Tink store. Apps can now detect those cases before accessing the storage.

There is no automatic migration for a direct v9 to v11 upgrade, and there will not be one because those old ciphers were intentionally removed in v11, which was also communicated trough the changelog.

The supported upgrade paths are:

* upgrade through a 10.3.x release first
* use `checkUpgradeStatus()` and re-authenticate or re-sync when old data cannot be read

Closes #1225, #1235, #1237
