### PR TITLE
fix: require flutter_secure_storage_platform_interface ^2.1.0 for checkUpgradeStatus

### DIFF
--- a/flutter_secure_storage/pubspec.yaml
+++ b/flutter_secure_storage/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   # https://github.com/flutter/flutter/issues/46264
   flutter_secure_storage_darwin: ^0.4.0
   flutter_secure_storage_linux: ^3.0.1
-  flutter_secure_storage_platform_interface: ^2.0.1
+  flutter_secure_storage_platform_interface: ^2.1.0
   flutter_secure_storage_web: ^2.1.1
   flutter_secure_storage_windows: ^4.2.2
   meta: ^1.16.0


### PR DESCRIPTION
flutter_secure_storage 11.1.0 calls `checkUpgradeStatus()` and re-exports `SecureStorageUpgradeStatus`, both added in platform_interface 2.1.0. The constraint was still `^2.0.1`, so a fresh resolve could pick 2.0.3 and fail to compile. Needs to land before the 11.1.0 release PR is merged.