### PR TITLE
fix(linux)!: stop the xdg:schema attribute from going stale after relabeling

### DIFF
--- a/flutter_secure_storage_linux/linux/include/Secret.hpp
+++ b/flutter_secure_storage_linux/linux/include/Secret.hpp
@@ -143,7 +143,15 @@ class SecretStorage {
 
 public:
   const char *getLabel() { return label.c_str(); }
-  void setLabel(const char *label) { this->label = label; }
+  const char *getSchemaName() { return the_schema.name; }
+
+  // Reassigning label can move its buffer (e.g. once the new value outgrows
+  // small-string optimization), which would leave the_schema.name, captured
+  // once in the constructor, dangling. Re-point it at the live buffer.
+  void setLabel(const char *label) {
+    this->label = label;
+    the_schema.name = this->label.c_str();
+  }
 
   SecretStorage(const char *_label = "default") : label(_label) {
     the_schema = {label.c_str(),

--- a/flutter_secure_storage_linux/linux/include/Secret.hpp
+++ b/flutter_secure_storage_linux/linux/include/Secret.hpp
@@ -145,9 +145,8 @@ public:
   const char *getLabel() { return label.c_str(); }
   const char *getSchemaName() { return the_schema.name; }
 
-  // Reassigning label can move its buffer (e.g. once the new value outgrows
-  // small-string optimization), which would leave the_schema.name, captured
-  // once in the constructor, dangling. Re-point it at the live buffer.
+  // Reassigning label can move its buffer, which would leave the_schema.name
+  // (captured once in the constructor) dangling. Re-point it at the live one.
   void setLabel(const char *label) {
     this->label = label;
     the_schema.name = this->label.c_str();
@@ -214,25 +213,109 @@ public:
 
   nlohmann::json readFromKeyring() {
     nlohmann::json value = nlohmann::json::object();
-    g_autoptr(GError) err = nullptr;
 
-    if (!warmupKeyring()) {
-      return value;
+    if (warmupKeyring()) {
+      g_autoptr(GError) err = nullptr;
+      secret_autofree gchar *result = secret_password_lookupv_sync(
+          &the_schema, m_attributes.getGHashTable(), nullptr, &err);
+
+      if (err) {
+        throw LibsecretError("secret_password_lookupv_sync", err);
+      }
+      if(result != NULL && strcmp(result, "") != 0){
+        value = nlohmann::json::parse(result);
+      }
+    }
+    // warmupKeyring() returning false (no default collection, nothing
+    // matching this schema) looks just like a fresh profile, so check for
+    // legacy data below in that case too, not just on an empty lookup.
+
+    // Nothing under this schema yet: check for data left behind under an
+    // older, incorrect schema value and bring it forward. Once anything has
+    // been written under the current schema this is skipped for good.
+    if (value.empty()) {
+      migrateLegacySchemaData(value);
     }
 
-    secret_autofree gchar *result = secret_password_lookupv_sync(
-        &the_schema, m_attributes.getGHashTable(), nullptr, &err);
-
-    if (err) {
-      throw LibsecretError("secret_password_lookupv_sync", err);
-    }
-    if(result != NULL && strcmp(result, "") != 0){
-      value = nlohmann::json::parse(result);
-    }
     return value;
   }
 
 private:
+  // Older builds could end up storing items under a bogus xdg:schema value
+  // instead of the intended "<application id>/FlutterSecureStorage". That
+  // value depended on std::string's internal layout, so there's no safe way
+  // to reconstruct it; instead this searches by the "account" attribute
+  // alone (schema = nullptr skips libsecret's xdg:schema matching entirely,
+  // see secret_service_search_sync) and pulls forward any match whose
+  // xdg:schema isn't already the current one.
+  //
+  // Best-effort only: every failure path here just returns without
+  // migrating rather than throwing, so a problem reaching legacy data never
+  // breaks the read that triggered this.
+  void migrateLegacySchemaData(nlohmann::json &current) {
+    g_autoptr(GError) err = nullptr;
+    SecretService *service =
+        secret_service_get_sync(SECRET_SERVICE_OPEN_SESSION, nullptr, &err);
+    if (!service) {
+      return;
+    }
+
+    GList *items = secret_service_search_sync(
+        service, /*schema=*/nullptr, m_attributes.getGHashTable(),
+        static_cast<SecretSearchFlags>(SECRET_SEARCH_ALL |
+                                       SECRET_SEARCH_LOAD_SECRETS),
+        nullptr, &err);
+    g_object_unref(service);
+    if (err) {
+      return;
+    }
+
+    bool changed = false;
+    for (GList *l = items; l != nullptr; l = l->next) {
+      SecretItem *item = SECRET_ITEM(l->data);
+
+      g_autoptr(GHashTable) item_attributes = secret_item_get_attributes(item);
+      const char *item_schema = item_attributes == nullptr
+          ? nullptr
+          : static_cast<const char *>(
+                g_hash_table_lookup(item_attributes, "xdg:schema"));
+      if (item_schema != nullptr && strcmp(item_schema, the_schema.name) == 0) {
+        continue;  // already under the current schema
+      }
+
+      SecretValue *secret_value = secret_item_get_secret(item);
+      if (secret_value == nullptr) {
+        continue;  // locked, or the search above couldn't load it
+      }
+      const gchar *raw = secret_value_get_text(secret_value);
+      if (raw != nullptr && raw[0] != '\0') {
+        try {
+          nlohmann::json legacy = nlohmann::json::parse(raw);
+          if (legacy.is_object()) {
+            for (auto &entry : legacy.items()) {
+              if (!current.contains(entry.key())) {
+                current[entry.key()] = entry.value();
+                changed = true;
+              }
+            }
+          }
+        } catch (const nlohmann::json::parse_error &) {
+          // Not our JSON blob; leave it alone.
+        }
+      }
+      secret_value_unref(secret_value);
+    }
+    if (items) {
+      g_list_free_full(items, g_object_unref);
+    }
+
+    // Legacy items are left in place: this only copies data forward, it
+    // never deletes, so a partial or repeated migration can't lose data.
+    if (changed) {
+      storeToKeyring(current);
+    }
+  }
+
   // Ensures the default keyring is accessible and distinguishes a locked
   // collection from other storage errors. A missing default collection is
   // the normal state of a fresh profile, not a locked keyring. Do not load

--- a/flutter_secure_storage_linux/linux/test/flutter_secure_storage_linux_plugin_test.cc
+++ b/flutter_secure_storage_linux/linux/test/flutter_secure_storage_linux_plugin_test.cc
@@ -226,5 +226,20 @@ TEST(SecretServiceOnSessionBusTest, MatchesConfiguredBusPolicy) {
   EXPECT_EQ(secretServiceOnSessionBus(), want);
 }
 
+// setLabel() used to leave the_schema.name pointing at label's old buffer.
+// A short initial label fits small-string optimization; relabeling to
+// something long enough to force a heap allocation used to leave the
+// schema name dangling/stale instead of tracking the new value.
+TEST(SecretStorageSchemaNameTest, SchemaNameTracksLabelAfterRelabel) {
+  SecretStorage storage("x");
+  const std::string long_label(
+      "com.example.somewhat_long_application_id/FlutterSecureStorage");
+
+  storage.setLabel(long_label.c_str());
+
+  EXPECT_STREQ(storage.getSchemaName(), long_label.c_str());
+  EXPECT_STREQ(storage.getSchemaName(), storage.getLabel());
+}
+
 }  // namespace test
 }  // namespace flutter_secure_storage_linux

--- a/flutter_secure_storage_linux/linux/test/flutter_secure_storage_linux_plugin_test.cc
+++ b/flutter_secure_storage_linux/linux/test/flutter_secure_storage_linux_plugin_test.cc
@@ -241,5 +241,51 @@ TEST(SecretStorageSchemaNameTest, SchemaNameTracksLabelAfterRelabel) {
   EXPECT_STREQ(storage.getSchemaName(), storage.getLabel());
 }
 
+// `legacy_` and `current_` share the same "account" attribute but use
+// different schema names/labels, standing in for an old item stored under
+// a stale schema value versus the current, correct one.
+class SchemaMigrationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    legacy_ = std::make_unique<SecretStorage>("fss_migration_test.legacy_schema");
+    legacy_->addAttribute("account", "fss_migration_test.secureStorage");
+    legacy_->deleteKeyring();
+
+    current_ = std::make_unique<SecretStorage>("fss_migration_test.current_schema");
+    current_->addAttribute("account", "fss_migration_test.secureStorage");
+    current_->deleteKeyring();
+  }
+
+  void TearDown() override {
+    legacy_->deleteKeyring();
+    current_->deleteKeyring();
+  }
+
+  std::unique_ptr<SecretStorage> legacy_;
+  std::unique_ptr<SecretStorage> current_;
+};
+
+TEST_F(SchemaMigrationTest, LegacyDataUnderDifferentSchemaIsPulledForward) {
+  ASSERT_TRUE(legacy_->addItem("legacy_key", "legacy_value"));
+
+  EXPECT_EQ(current_->getItem("legacy_key"), "legacy_value");
+
+  // Copied forward, not moved: the legacy item is left in place.
+  EXPECT_EQ(legacy_->getItem("legacy_key"), "legacy_value");
+}
+
+TEST_F(SchemaMigrationTest, SkipsMigrationOnceCurrentSchemaHasAnyData) {
+  ASSERT_TRUE(current_->addItem("unrelated", "value"));
+  ASSERT_TRUE(legacy_->addItem("legacy_only_key", "legacy_value"));
+
+  // Migration only runs while the current schema is still completely empty;
+  // once it holds anything, later legacy writes must not appear in it.
+  EXPECT_EQ(current_->getItem("legacy_only_key"), "");
+}
+
+TEST_F(SchemaMigrationTest, NoLegacyDataIsNoOp) {
+  EXPECT_EQ(current_->getItem("missing"), "");
+}
+
 }  // namespace test
 }  // namespace flutter_secure_storage_linux


### PR DESCRIPTION
  Fixes #1181. setLabel() reassigned the label string but never refreshed the cached SecretSchema.name pointer, which the constructor had pointed at the label's original buffer. Once the real label (<applicationid>/FlutterSecureStorage) outgrows small-string optimization, reassigning it relocates the buffer, so the xdg:schema attribute libsecret sends ends up stale instead of the intended value.                             
                                                                                                                                                                                                                          
  This is a breaking change: existing installs have secrets stored under whatever incorrect xdg:schema value they happened to compute. Rather than trying to reproduce that value (it depends on std::string's internal layout, not something safe to reconstruct), this migrates by searching for the account attribute alone, ignoring schema entirely, and copies any match forward into the correct schema. Legacy items are left in place, nothing is deleted.                                                                                                                                                                                                     
                                                                                                                                                                                                                          
  Verified against a real libsecret/gnome-keyring/D-Bus stack in Docker.                                                                                                       
                                                                                                                                                                                                                          
  **Checklist**                                                                                                                                                                                                               
                                                                                                                                                                                                                          
  - [x] The PR title follows Conventional Commits.                                                                                                                                                                        
  - [x] Tests were added or updated.                                                                                                                                                                                      
  - [x] Documentation (README.md) was updated, if applicable.