### PR TITLE
fix(android): read saved key-cipher marker instead of toString() on a KeyCipher

### DIFF
--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
@@ -242,7 +242,7 @@ public class FlutterSecureStorage {
 
         try {
             // Determine if this is a biometric migration
-            String savedStorageAlg = storageCipherFactory.getSavedKeyCipher(context).toString();
+            String savedStorageAlg = StorageCipherFactory.readSavedKeyAlgorithm(configSource);
             String currentStorageAlg = config.getPrefOptionStorageCipherAlgorithm();
 
             boolean fromBiometric = isBiometricAlgorithm(savedStorageAlg);


### PR DESCRIPTION
Fixes #1255. migrateData() called getSavedKeyCipher(context).toString() to detect whether the saved algorithm was biometric, but KeyCipher never overrides toString(), so it fell back to Object's class@hashcode. That string can never contain "BIOMETRIC", so fromBiometric was always false and a legacy biometric-protected key could be migrated down the non-authenticated path, breaking decryption.

Uses the existing (previously unused) readSavedKeyAlgorithm() helper to read the actual persisted marker instead.

**Checklist**

- [x] The PR title follows Conventional Commits.
- [ ] Tests were added or updated, if applicable.
- [ ] Documentation (README.md) was updated, if applicable.